### PR TITLE
fix for #868

### DIFF
--- a/src/components/explorer/results/QueryResultsContainer.js
+++ b/src/components/explorer/results/QueryResultsContainer.js
@@ -13,7 +13,7 @@ import QueryGeoResultsContainer from './QueryGeoResultsContainer';
 import QueryWordsResultsContainer from './QueryWordsResultsContainer';
 import QueryWordSpaceResultsContainer from './QueryWordSpaceResultsContainer';
 import QueryViewSelector from './QueryViewSelector';
-import QueryThemesResultsContainer from './QueryThemesResultsContainer';
+// import QueryThemesResultsContainer from './QueryThemesResultsContainer';
 import { updateQuery } from '../../../actions/explorerActions';
 
 class QueryResultsContainer extends React.Component {
@@ -37,14 +37,6 @@ class QueryResultsContainer extends React.Component {
             lastSearchTime={lastSearchTime}
             queries={queries}
             isLoggedIn={isLoggedIn}
-          />
-        </Col>
-        <Col lg={12}>
-          <QueryThemesResultsContainer
-            lastSearchTime={lastSearchTime}
-            queries={queries}
-            isLoggedIn={isLoggedIn}
-            onQueryModificationRequested={handleQueryModificationRequested}
           />
         </Col>
         <Col lg={12} xs={12}>

--- a/src/components/explorer/results/QueryWordComparisonResultsContainer.js
+++ b/src/components/explorer/results/QueryWordComparisonResultsContainer.js
@@ -4,7 +4,7 @@ import { FormattedHTMLMessage, FormattedMessage, injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import { Grid, Row, Col } from 'react-flexbox-grid/lib';
 import composeAsyncContainer from '../../common/AsyncContainer';
-import { fetchQueryTopWordsComparison, fetchDemoQueryTopWordsComparison, selectComparativeWordField, updateQuery } from '../../../actions/explorerActions';
+import { fetchQueryTopWordsComparison, fetchDemoQueryTopWordsComparison, selectComparativeWordField, resetTopWordsComparison, updateQuery } from '../../../actions/explorerActions';
 import { queryChangedEnoughToUpdate } from '../../../lib/explorerUtil';
 import { getBrandDarkColor } from '../../../styles/colors';
 import ComparativeOrderedWordCloud from '../../vis/ComparativeOrderedWordCloud';
@@ -32,8 +32,12 @@ class QueryWordComparisonResultsContainer extends React.Component {
     }
   }
   componentWillReceiveProps(nextProps) {
-    const { lastSearchTime, fetchData, leftQuery, rightQuery } = this.props;
+    const { lastSearchTime, fetchData, queries, leftQuery, rightQuery, selectComparativeWords } = this.props;
     if (nextProps.lastSearchTime !== lastSearchTime) {
+      const leftQ = queries[0];
+      const rightQ = queries.length > 1 ? queries[1] : queries[0];
+      selectComparativeWords(leftQ, LEFT);
+      selectComparativeWords(rightQ, RIGHT);
       fetchData([leftQuery, rightQuery]);
     }
   }
@@ -43,10 +47,6 @@ class QueryWordComparisonResultsContainer extends React.Component {
     // also check if they changed their view choices
     return (shouldChange || (nextProps.leftQuery !== leftQuery || nextProps.rightQuery !== rightQuery)
     );
-  }
-
-  componentWillUnmount() {
-    this.setState({ leftQuery: '', rightQuery: '' });
   }
 
   selectAndFetchComparedQueries = (queryObj, target) => {
@@ -169,7 +169,7 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
   fetchData: (queries) => {
     // this should trigger when the user clicks the Search button or changes the URL
     // for n queries, run the dispatch with each parsed query
-    // dispatch(resetTopWordsComparison()); // necessary if a query deletion has occurred
+    dispatch(resetTopWordsComparison()); // necessary if a query deletion has occurred
     if (ownProps.isLoggedIn) {
       const runTheseQueries = queries || ownProps.queries;
       const comparedQueries = runTheseQueries.map(q => ({

--- a/src/components/explorer/results/QueryWordComparisonResultsContainer.js
+++ b/src/components/explorer/results/QueryWordComparisonResultsContainer.js
@@ -26,15 +26,27 @@ class QueryWordComparisonResultsContainer extends React.Component {
     const { queries, selectComparativeWords } = this.props;
     const leftQ = queries[0];
     const rightQ = queries.length > 1 ? queries[1] : queries[0];
-    selectComparativeWords(leftQ, LEFT);
-    selectComparativeWords(rightQ, RIGHT);
+    if (leftQ === null) {
+      selectComparativeWords(leftQ, LEFT); // default selection
+      selectComparativeWords(rightQ, RIGHT);
+    }
   }
   componentWillReceiveProps(nextProps) {
-    const { lastSearchTime, fetchData, selectComparativeWords } = this.props;
+    const { lastSearchTime, fetchData, selectComparativeWords, leftQuery, rightQuery } = this.props;
+    let leftQ = null;
+    let rightQ = null;
     if (nextProps.lastSearchTime !== lastSearchTime) {
-      // this won't work if we have more than 2 queries...
-      const leftQ = nextProps.queries[0];
-      const rightQ = nextProps.queries.length > 1 ? nextProps.queries[1] : nextProps.queries[0];
+      // if a search query change from the top
+      leftQ = nextProps.queries[0];
+      rightQ = nextProps.queries.length > 1 ? nextProps.queries[1] : nextProps.queries[0];
+      selectComparativeWords(leftQ, LEFT);
+      selectComparativeWords(rightQ, RIGHT);
+      fetchData([leftQ, rightQ]);
+    } else if (nextProps.leftQuery !== leftQuery ||
+      nextProps.rightQuery !== rightQuery) {
+      // if a change in the comparison UI selection
+      leftQ = nextProps.leftQuery;
+      rightQ = nextProps.rightQuery;
       selectComparativeWords(leftQ, LEFT);
       selectComparativeWords(rightQ, RIGHT);
       fetchData([leftQ, rightQ]);

--- a/src/components/explorer/results/QueryWordComparisonResultsContainer.js
+++ b/src/components/explorer/results/QueryWordComparisonResultsContainer.js
@@ -23,22 +23,21 @@ const RIGHT = 1;
 
 class QueryWordComparisonResultsContainer extends React.Component {
   componentWillMount() {
-    const { queries, leftQuery, selectComparativeWords } = this.props;
-    if (leftQuery === null) { // selections haven't been set yet so do init
-      const leftQ = queries[0];
-      const rightQ = queries.length > 1 ? queries[1] : queries[0];
-      selectComparativeWords(leftQ, LEFT);
-      selectComparativeWords(rightQ, RIGHT);
-    }
+    const { queries, selectComparativeWords } = this.props;
+    const leftQ = queries[0];
+    const rightQ = queries.length > 1 ? queries[1] : queries[0];
+    selectComparativeWords(leftQ, LEFT);
+    selectComparativeWords(rightQ, RIGHT);
   }
   componentWillReceiveProps(nextProps) {
-    const { lastSearchTime, fetchData, queries, leftQuery, rightQuery, selectComparativeWords } = this.props;
+    const { lastSearchTime, fetchData, selectComparativeWords } = this.props;
     if (nextProps.lastSearchTime !== lastSearchTime) {
-      const leftQ = queries[0];
-      const rightQ = queries.length > 1 ? queries[1] : queries[0];
+      // this won't work if we have more than 2 queries...
+      const leftQ = nextProps.queries[0];
+      const rightQ = nextProps.queries.length > 1 ? nextProps.queries[1] : nextProps.queries[0];
       selectComparativeWords(leftQ, LEFT);
       selectComparativeWords(rightQ, RIGHT);
-      fetchData([leftQuery, rightQuery]);
+      fetchData([leftQ, rightQ]);
     }
   }
   shouldComponentUpdate(nextProps) {

--- a/src/reducers/explorer/topWordsComparison.js
+++ b/src/reducers/explorer/topWordsComparison.js
@@ -21,6 +21,8 @@ const topWordsComparison = createAsyncReducer({
   },
   [RESET_QUERY_TOP_WORDS_COMPARISON]: () => ({
     list: [],
+    left: null,
+    right: null,
   }),
 });
 export default topWordsComparison;

--- a/src/reducers/explorer/topWordsComparison.js
+++ b/src/reducers/explorer/topWordsComparison.js
@@ -6,23 +6,22 @@ const LEFT = 0;
 
 const topWordsComparison = createAsyncReducer({
   initialState: ({
-    list: [],
-    left: null,
+    list: [], // list of words
+    left: null, // ui component selection
     right: null,
   }),
   action: FETCH_QUERY_TOP_WORDS_COMPARISON,
   handleSuccess: payload => ({
-    // don't update left and right here because data (collections for example) may be packaged incorrectly
+    // result of left and right queries
     list: payload.list,
   }),
   [SELECT_COMPARATIVE_WORD_FIELD]: (payload) => {
+    // store query selection
     if (payload.target === LEFT) return { left: payload.query };
     return { right: payload.query };
   },
   [RESET_QUERY_TOP_WORDS_COMPARISON]: () => ({
     list: [],
-    left: null,
-    right: null,
   }),
 });
 export default topWordsComparison;


### PR DESCRIPTION
If from the search button, act as if a new page mount,
If from the UI comparison widget, switch out the word clouds