### PR TITLE
Use new `num_stories_90` for media story count

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ MarkupSafe==0.23
 Werkzeug==0.11.10
 click==6.6
 itsdangerous==0.24
-mediacloud==2.50.0
+mediacloud==2.51.0
 ndg-httpsclient==0.4.1
 pyOpenSSL==16.2.0
 pyasn1==0.1.9

--- a/server/views/media_picker.py
+++ b/server/views/media_picker.py
@@ -21,50 +21,17 @@ MEDIA_SEARCH_POOL_SIZE = len(VALID_COLLECTION_TAG_SETS_IDS)
 STORY_COUNT_POOL_SIZE = 20  # number of parallel processes to use while fetching historical sentence counts for sources
 
 
-def source_details_worker(info):
-    # getting media health is super fast, so we don't even need to cache it
-    health = mc.mediaHealth(info['media_id'])  # this has aggregate story counts to use instead of querying for them
-    weekly_story_count = 0 if len(health) is 0 else int(health['num_stories_w']) # sometimes health is an empty list - WTF
-    collection_info = {
-        'media_id': info['media_id'],
-        'label': info['name'],
-        'name': info['name'],
-        'url': info['url'],
-        'public_notes': info['public_notes'],
-        'weekly_story_count': weekly_story_count,
-    }
-    return collection_info
-
-
 @app.route('/api/mediapicker/sources/search', methods=['GET'])
 @flask_login.login_required
 @arguments_required('media_keyword')
 @api_error_handler
 def api_mediapicker_source_search():
-    t0 = time.time()
-    use_pool = True
     search_str = request.args['media_keyword']
     cleaned_search_str = None if search_str == '*' else search_str
     tags = None
     if 'tags' in request.args:
         tags = request.args['tags'].split(',')
-    t1 = time.time()
     matching_sources = media_search(cleaned_search_str, tags)
-    t2 = time.time()
-    if use_pool:
-        pool = Pool(processes=STORY_COUNT_POOL_SIZE)
-        matching_sources = pool.map(source_details_worker, matching_sources)
-        pool.close()
-    else:
-        matching_sources = [source_details_worker(s) for s in matching_sources]
-    t3 = time.time()
-    matching_sources = sorted(matching_sources, key=itemgetter('weekly_story_count'), reverse=True)
-    t4 = time.time()
-    logger.debug("total: {}".format(t4 - t0))
-    logger.debug("  load: {}".format(t1-t0))
-    logger.debug("  search: {}".format(t2 - t1))
-    logger.debug("  source_health: {}".format(t3 - t2))
-    logger.debug("  sort: {}".format(t4 - t3))
     return jsonify({'list': matching_sources})
 
 

--- a/server/views/media_search.py
+++ b/server/views/media_search.py
@@ -4,12 +4,12 @@ from server.auth import user_mediacloud_client
 
 logger = logging.getLogger(__name__)
 
-MAX_SOURCES = 60
+MAX_SOURCES = 40
 
 
 def media_search(search_str, tags_id=None):
     mc = user_mediacloud_client()
-    return mc.mediaList(name_like=search_str, tags_id=tags_id, rows=MAX_SOURCES)
+    return mc.mediaList(name_like=search_str, tags_id=tags_id, rows=MAX_SOURCES, sort="num_stories")
 
 
 def collection_search(search_str, public_only, tag_sets_id_list):

--- a/src/components/common/mediaPicker/results/SourceResultsTable.js
+++ b/src/components/common/mediaPicker/results/SourceResultsTable.js
@@ -7,7 +7,7 @@ import { urlToSource } from '../../../../lib/urlUtil';
 const localMessages = {
   name: { id: 'mediaPicker.searchResults.name', defaultMessage: 'Name' },
   url: { id: 'mediaPicker.searchResults.url', defaultMessage: 'URL' },
-  storiesLastWeek: { id: 'mediaPicker.searchResults.storiesLastWeek', defaultMessage: 'Stories per Week' },
+  recentStoryCount: { id: 'mediaPicker.searchResults.recentStoryCount', defaultMessage: 'Stories in the Past 90 Days' },
   noResults: { id: 'mediaPicker.searchResults.noResults', defaultMessage: 'No matching sources' },
 };
 
@@ -21,7 +21,7 @@ const SourceResultsTable = (props) => {
           <tr>
             <th><FormattedMessage {...localMessages.name} /></th>
             <th><FormattedMessage {...localMessages.url} /></th>
-            <th className="numeric"><FormattedMessage {...localMessages.storiesLastWeek} /></th>
+            <th className="numeric"><FormattedMessage {...localMessages.recentStoryCount} /></th>
             <th />
           </tr>
           {sources.map((s, idx) => {
@@ -31,7 +31,7 @@ const SourceResultsTable = (props) => {
               <tr key={`${s.media_id}`} className={(idx % 2 === 0) ? 'even' : 'odd'}>
                 <td><a href={urlToSource(s.media_id)} target="new">{s.name}</a></td>
                 <td>{s.url}</td>
-                <td className="numeric"><FormattedNumber value={s.weekly_story_count} /></td>
+                <td className="numeric"><FormattedNumber value={Math.round(s.num_stories_90)} /></td>
                 <td>{actionContent}</td>
               </tr>
             );

--- a/src/components/common/mediaPicker/results/SourceResultsTable.js
+++ b/src/components/common/mediaPicker/results/SourceResultsTable.js
@@ -7,7 +7,7 @@ import { urlToSource } from '../../../../lib/urlUtil';
 const localMessages = {
   name: { id: 'mediaPicker.searchResults.name', defaultMessage: 'Name' },
   url: { id: 'mediaPicker.searchResults.url', defaultMessage: 'URL' },
-  recentStoryCount: { id: 'mediaPicker.searchResults.recentStoryCount', defaultMessage: 'Stories in the Past 90 Days' },
+  recentStoryCount: { id: 'mediaPicker.searchResults.recentStoryCount', defaultMessage: 'Stories per Day' },
   noResults: { id: 'mediaPicker.searchResults.noResults', defaultMessage: 'No matching sources' },
 };
 


### PR DESCRIPTION
When searching for media with `mediaList` we don't need to do a pool'ed call for mediaHealth to get the story count anymore (thanks to https://github.com/berkmancenter/mediacloud/issues/316).  Now results from that call come back with a `num_stories_90` value, which is the number of stories per day avg over the last 90 days.  We're using this in the media picker now to show the story count, and using the new `sort=num_stories` arg to sort by that automatically (so results from bigger/healthier matching sources bubble up to the top of the list)