### PR TITLE
refactor csv download notification

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,15 +22,16 @@
     "no-bitwise": ["error", { "allow": ["~"] }],
     "react/no-danger": 0,
     "react/no-unused-prop-types": 0,
+    "import/no-named-as-default": 0,
     "comma-dangle": ["error", {
       "arrays": "always-multiline",
       "objects": "always-multiline",
       "imports": "always-multiline",
       "exports": "always-multiline",
-      "functions": "ignore",
+      "functions": "ignore"
     }],
     "react/require-default-props": 0,
     "react/no-array-index-key": 0,
-    "click-events-have-key-events": 0,
+    "click-events-have-key-events": 0
  }
 }

--- a/src/components/AppContainer.js
+++ b/src/components/AppContainer.js
@@ -72,6 +72,8 @@ const AppContainer = (props) => {
       <Snackbar
         open={feedback.open}
         message={feedback.message}
+        action={feedback.action}
+        onActionClick={feedback.onActionClick}
         autoHideDuration={8000}
         onRequestClose={handleSnackBarRequestClose}
       />

--- a/src/components/common/SourceList.js
+++ b/src/components/common/SourceList.js
@@ -14,7 +14,7 @@ const localMessages = {
 };
 
 const SourceList = (props) => {
-  const { sources, title, intro, downloadUrl, extraHeaderColumns, extraColumns, addAppNotice } = props;
+  const { sources, title, intro, downloadUrl, extraHeaderColumns, extraColumns, onDownload } = props;
   const { formatMessage } = props.intl;
 
   let titleRefactor = null;
@@ -42,7 +42,7 @@ const SourceList = (props) => {
   return (
     <DataCard className="source-list">
       {downloadUrl && <div className="actions">
-        <DownloadButton tooltip={formatMessage(messages.download)} onClick={() => { window.location = downloadUrl; addAppNotice(); }} />
+        <DownloadButton tooltip={formatMessage(messages.download)} onClick={() => { window.location = downloadUrl; onDownload(); }} />
       </div>}
       <h2>{titleRefactor}</h2>
       <p>
@@ -63,7 +63,7 @@ SourceList.propTypes = {
   downloadUrl: PropTypes.string,
   extraHeaderColumns: PropTypes.func,
   extraColumns: PropTypes.func,
-  addAppNotice: PropTypes.func,
+  onDownload: PropTypes.func,
 };
 
 export default

--- a/src/components/common/composers/CsvDownloadNotifyContainer.js
+++ b/src/components/common/composers/CsvDownloadNotifyContainer.js
@@ -1,0 +1,47 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { injectIntl } from 'react-intl';
+import { connect } from 'react-redux';
+import messages from '../../../resources/messages';
+import { updateFeedback } from '../../../actions/appActions';
+
+/**
+ * Wrap any component that wants to show a notification about a CSV download starting. This passes
+ * a `notifyOfCsvDownload` helper to the child component, which can accept a URL to link to. If that url
+ * is passed in, the notification shows that as a link for more details about the download.
+ */
+const composeCsvDownloadNotifyContainer = (ChildComponent) => {
+  const CsvDownloadNotifyContainer = props => (
+    <div className="csv-download-notifier">
+      <ChildComponent {...props} notifyOfCsvDownload={props.notifyOfCsvDownload} />
+    </div>
+  );
+
+  CsvDownloadNotifyContainer.propTypes = {
+    intl: PropTypes.object.isRequired,
+    notifyOfCsvDownload: PropTypes.func.isRequired,
+  };
+
+  const mapDispatchToProps = (dispatch, ownProps) => ({
+    notifyOfCsvDownload: (urlToDetails) => {  // can handle case with no URL to show for details about the download
+      const htmlMessage = ownProps.intl.formatMessage(messages.currentlyDownloadingCsv);
+      dispatch(updateFeedback({
+        open: true,
+        message: htmlMessage,
+        action: (urlToDetails) ? ownProps.intl.formatHTMLMessage(messages.learnMoreAboutColumnsCsv) : undefined,
+        onActionClick: (urlToDetails) ? () => {
+          const win = window.open(urlToDetails, '_blank');
+          win.focus();
+        } : undefined,
+      }));
+    },
+  });
+
+  return connect(null, mapDispatchToProps)(
+    injectIntl(
+      CsvDownloadNotifyContainer
+    )
+  );
+};
+
+export default composeCsvDownloadNotifyContainer;

--- a/src/components/source/collection/CollectionUploadSourceContainer.js
+++ b/src/components/source/collection/CollectionUploadSourceContainer.js
@@ -3,12 +3,12 @@ import React from 'react';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import { uploadSourceListFromTemplate } from '../../../actions/sourceActions';
-import { updateFeedback, addNotice } from '../../../actions/appActions';
+import { updateFeedback } from '../../../actions/appActions';
 import LoadingSpinner from '../../common/LoadingSpinner';
 import CollectionUploadConfirmer from './form/CollectionUploadConfirmer';
+import composeCsvDownloadNotifyContainer from '../../common/composers/CsvDownloadNotifyContainer';
 import { DownloadButton } from '../../common/IconButton';
 import messages from '../../../resources/messages';
-import { LEVEL_INFO } from '../../common/Notice';
 import { HELP_SOURCES_CSV_COLUMNS } from '../../../lib/helpConstants';
 
 const localMessages = {
@@ -22,7 +22,7 @@ const localMessages = {
 class CollectionUploadSourceContainer extends React.Component {
 
   downloadCsv = (evt) => {
-    const { myCollectionId, addAppNotice } = this.props;
+    const { myCollectionId, notifyOfCsvDownload } = this.props;
     if (evt) {
       evt.preventDefault();
     }
@@ -33,7 +33,7 @@ class CollectionUploadSourceContainer extends React.Component {
       url = '/api/template/sources.csv';
     }
     window.location = url;
-    addAppNotice();
+    notifyOfCsvDownload(HELP_SOURCES_CSV_COLUMNS);
   }
   selectedCSV = () => {
     this.setState({ confirmTemplate: true });
@@ -95,10 +95,10 @@ CollectionUploadSourceContainer.propTypes = {
   mysources: PropTypes.array,
   myCollectionId: PropTypes.string,
   // from parent
-  // from composition
+  // from compositional chain
+  notifyOfCsvDownload: PropTypes.func.isRequired,
   intl: PropTypes.object.isRequired,
   uploadCSVFile: PropTypes.func.isRequired,
-  addAppNotice: PropTypes.func,
 };
 
 const mapStateToProps = state => ({
@@ -117,16 +117,13 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
         }
       });
   },
-  addAppNotice: () => {
-    let htmlMessage = ownProps.intl.formatMessage(messages.currentlyDownloadingCsv);
-    htmlMessage = `${htmlMessage} <a href="${HELP_SOURCES_CSV_COLUMNS}">${ownProps.intl.formatHTMLMessage(messages.learnMoreAboutColumnsCsv)}</a>`;
-    dispatch(addNotice({ level: LEVEL_INFO, htmlMessage }));
-  },
 });
 
 export default
   injectIntl(
     connect(mapStateToProps, mapDispatchToProps)(
-      CollectionUploadSourceContainer
+      composeCsvDownloadNotifyContainer(
+        CollectionUploadSourceContainer
+      )
     )
   );

--- a/src/components/topic/media/MediaStoriesContainer.js
+++ b/src/components/topic/media/MediaStoriesContainer.js
@@ -5,14 +5,13 @@ import { connect } from 'react-redux';
 import { push } from 'react-router-redux';
 import { fetchMediaStories, sortMediaStories, filterByFocus } from '../../../actions/topicActions';
 import composeAsyncContainer from '../../common/AsyncContainer';
+import composeCsvDownloadNotifyContainer from '../../common/composers/CsvDownloadNotifyContainer';
 import composeHelpfulContainer from '../../common/HelpfulContainer';
 import messages from '../../../resources/messages';
 import TopicStoryTable from '../TopicStoryTable';
 import { filteredLocation, filtersAsUrlParams } from '../../util/location';
 import DataCard from '../../common/DataCard';
 import { DownloadButton } from '../../common/IconButton';
-import { LEVEL_INFO } from '../../common/Notice';
-import { addNotice } from '../../../actions/appActions';
 import { HELP_STORIES_CSV_COLUMNS } from '../../../lib/helpConstants';
 
 const STORIES_TO_SHOW = 10;
@@ -35,10 +34,11 @@ class MediaStoriesContainer extends React.Component {
     sortData(newSort);
   }
   downloadCsv = () => {
-    const { mediaId, topicId, filters } = this.props;
+    const { mediaId, topicId, filters, notifyOfCsvDownload } = this.props;
     const filtersAsParams = filtersAsUrlParams(filters);
     const url = `/api/topics/${topicId}/media/${mediaId}/stories.csv?${filtersAsParams}`;
     window.location = url;
+    notifyOfCsvDownload(HELP_STORIES_CSV_COLUMNS);
   }
   render() {
     const { inlinkedStories, showTweetCounts, topicId, helpButton, handleFocusSelected } = this.props;
@@ -68,6 +68,7 @@ MediaStoriesContainer.propTypes = {
   // from composition chain
   intl: PropTypes.object.isRequired,
   helpButton: PropTypes.node.isRequired,
+  notifyOfCsvDownload: PropTypes.func.isRequired,
   // from parent
   mediaId: PropTypes.number.isRequired,
   topicId: PropTypes.number.isRequired,
@@ -110,11 +111,6 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
   sortData: (sort) => {
     dispatch(sortMediaStories(sort));
   },
-  addAppNotice: () => {
-    let htmlMessage = ownProps.intl.formatMessage(messages.currentlyDownloadingCsv);
-    htmlMessage = `${htmlMessage} <a href="${HELP_STORIES_CSV_COLUMNS}">${ownProps.intl.formatHTMLMessage(messages.learnMoreAboutColumnsCsv)}</a>`;
-    dispatch(addNotice({ level: LEVEL_INFO, htmlMessage }));
-  },
 });
 
 function mergeProps(stateProps, dispatchProps, ownProps) {
@@ -130,7 +126,9 @@ export default
     connect(mapStateToProps, mapDispatchToProps, mergeProps)(
       composeHelpfulContainer(localMessages.helpTitle, [localMessages.helpIntro, messages.storiesTableHelpText])(
         composeAsyncContainer(
-          MediaStoriesContainer
+          composeCsvDownloadNotifyContainer(
+            MediaStoriesContainer
+          )
         )
       )
     )

--- a/src/components/topic/words/WordStoriesContainer.js
+++ b/src/components/topic/words/WordStoriesContainer.js
@@ -4,12 +4,11 @@ import { FormattedMessage, injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import { fetchWordStories, sortWordStories } from '../../../actions/topicActions';
 import composeAsyncContainer from '../../common/AsyncContainer';
+import composeCsvDownloadNotifyContainer from '../../common/composers/CsvDownloadNotifyContainer';
 import composeHelpfulContainer from '../../common/HelpfulContainer';
 import messages from '../../../resources/messages';
-import { LEVEL_INFO } from '../../common/Notice';
 import TopicStoryTable from '../TopicStoryTable';
 import DataCard from '../../common/DataCard';
-import { addNotice } from '../../../actions/appActions';
 import { DownloadButton } from '../../common/IconButton';
 import { filtersAsUrlParams } from '../../util/location';
 import { HELP_STORIES_CSV_COLUMNS } from '../../../lib/helpConstants';
@@ -36,10 +35,10 @@ class WordStoriesContainer extends React.Component {
     sortData(newSort);
   }
   downloadCsv = () => {
-    const { term, topicId, filters, addAppNotice } = this.props;
+    const { term, topicId, filters, notifyOfCsvDownload } = this.props;
     const url = `/api/topics/${topicId}/words/${term}*/stories.csv?${filtersAsUrlParams(filters)}`;
     window.location = url;
-    addAppNotice();
+    notifyOfCsvDownload(HELP_STORIES_CSV_COLUMNS);
   }
   render() {
     const { inlinkedStories, topicId, helpButton, showTweetCounts } = this.props;
@@ -63,6 +62,7 @@ WordStoriesContainer.propTypes = {
   // from composition chain
   intl: PropTypes.object.isRequired,
   helpButton: PropTypes.node.isRequired,
+  notifyOfCsvDownload: PropTypes.func.isRequired,
   // from parent
   stem: PropTypes.string.isRequired,
   term: PropTypes.string.isRequired,
@@ -78,7 +78,6 @@ WordStoriesContainer.propTypes = {
   fetchStatus: PropTypes.string.isRequired,
   inlinkedStories: PropTypes.array.isRequired,
   showTweetCounts: PropTypes.bool,
-  addAppNotice: PropTypes.func,
 };
 
 const mapStateToProps = state => ({
@@ -101,11 +100,6 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
   sortData: (sort) => {
     dispatch(sortWordStories(sort));
   },
-  addAppNotice: () => {
-    let htmlMessage = ownProps.intl.formatMessage(messages.currentlyDownloadingCsv);
-    htmlMessage = `${htmlMessage} <a href="${HELP_STORIES_CSV_COLUMNS}">${ownProps.intl.formatHTMLMessage(messages.learnMoreAboutColumnsCsv)}</a>`;
-    dispatch(addNotice({ level: LEVEL_INFO, htmlMessage }));
-  },
 });
 
 function mergeProps(stateProps, dispatchProps, ownProps) {
@@ -121,10 +115,10 @@ export default
     connect(mapStateToProps, mapDispatchToProps, mergeProps)(
       composeHelpfulContainer(localMessages.helpTitle, [localMessages.helpIntro, messages.storiesTableHelpText])(
         composeAsyncContainer(
-          WordStoriesContainer
+          composeCsvDownloadNotifyContainer(
+            WordStoriesContainer
+          )
         )
       )
     )
   );
-
-// lightweight wrapper around a TopicStoryTable


### PR DESCRIPTION
The existing solution fires an alert notice at the top of the screen, rather than a move passive snackbar notification at the bottom of the screen.  This PR changes that.

More importantly, the existing solution includes a lot of repeated code, making it hard to refactor.  I would have to change 7-ish files that use this pattern in order to refactor it from a `Notice` to a `Snackbar` :-( To address this architecture problem I created a new wrapper class following the composition pattern.  This new `composeCsvDownloadNotifyContainer` can be used to wrap any class, and supplies a `notifyOfCsvDownload` method that the child can use.  Now if we want to change the implementation we can just change how that one method is using the underlying widgets.