### PR TITLE
Centralize generation of source list CSV downloads

### DIFF
--- a/server/util/csv.py
+++ b/server/util/csv.py
@@ -4,6 +4,8 @@ import flask
 
 from server.util.tags import label_for_metadata_tag
 
+SOURCE_LIST_CSV_METADATA_PROPS = ['pub_country', 'pub_state', 'language', 'about_country', 'media_type']
+
 logger = logging.getLogger(__name__)
 
 

--- a/server/util/csv.py
+++ b/server/util/csv.py
@@ -2,6 +2,8 @@ import logging
 import datetime
 import flask
 
+from server.util.tags import label_for_metadata_tag
+
 logger = logging.getLogger(__name__)
 
 
@@ -69,29 +71,14 @@ def stream_response(data, dict_keys, filename, column_names=None, as_attachment=
                               mimetype='text/csv; charset=utf-8', headers=headers)
 
 
-def download_media_csv(all_media, file_prefix, properties):
-    modified_properties = properties + ['stories_per_day', 'first_story',
-                                        'pub_country', 'pub_state', 'language',
-                                        'about_country', 'media_type']
-
+def download_media_csv(all_media, file_prefix, column_names):
     for src in all_media:
-        if 'editor_notes' in properties and 'editor_notes' not in src:
+        if 'editor_notes' in column_names and 'editor_notes' not in src:
             src['editor_notes'] = ''
-        if 'is_monitored' in properties and 'is_monitored' not in src:
+        if 'is_monitored' in column_names and 'is_monitored' not in src:
             src['is_monitored'] = ''
-        if 'public_notes' in properties and 'public_notes' not in src:
+        if 'public_notes' in column_names and 'public_notes' not in src:
             src['public_notes'] = ''
-        # handle nulls
-        if 'pub_country' not in src:
-            src['pub_country'] = ''
-        if 'pub_state' not in src:
-            src['pub_state'] = ''
-        if 'primary_language' not in src:
-            src['primary_language'] = ''
-        if 'subject_country' not in src:
-            src['subject_country'] = ''
-        if 'media_type' not in src:
-            src['media_type'] = ''
         if 'num_stories_90' not in src:
             src['num_stories_90'] = ''
         if 'start_date' not in src:
@@ -100,10 +87,11 @@ def download_media_csv(all_media, file_prefix, properties):
             src['end_date'] = ''
         src['stories_per_day'] = src['num_stories_90']
         src['first_story'] = src['start_date']
+
         if 'metadata' not in src:
             src['metadata'] = ''
         else:
-            for k, v in src['metadata'].iteritems():
-                src[k] = v['label'] if v is not None else None
+            for name, tag in src['metadata'].iteritems():
+                src[name] = label_for_metadata_tag(tag) if tag is not None else None
 
-    return stream_response(all_media, modified_properties, file_prefix, modified_properties)
+    return stream_response(all_media, column_names, file_prefix, column_names)

--- a/server/util/tags.py
+++ b/server/util/tags.py
@@ -96,18 +96,20 @@ def format_name_from_label(user_label):
     return formatted_name
 
 
-def format_metadata_fields(media_dict, tag):
+def label_for_metadata_tag(tag):
+    label = None
     tag_sets_id = tag['tag_sets_id']
     if tag_sets_id == TAG_SETS_ID_PUBLICATION_COUNTRY:
-        media_dict['pub_country'] = tag['tag'][-3:]
+        label = tag['tag'][-3:]
     elif tag_sets_id == TAG_SETS_ID_PUBLICATION_STATE:
-        media_dict['pub_state'] = tag['tag'][4:]
+        label = tag['tag'][4:]
     elif tag_sets_id == TAG_SETS_ID_PRIMARY_LANGUAGE:
-        media_dict['primary_language'] = tag['tag']
+        label = tag['tag']
     elif tag_sets_id == TAG_SETS_ID_COUNTRY_OF_FOCUS:
-        media_dict['subject_country'] = tag['tag']
+        label = tag['tag']
     elif tag_sets_id == TAG_SETS_ID_MEDIA_TYPE:
-        media_dict['media_type'] = tag['tag']
+        label = tag['tag']
+    return label
 
 static_tag_set_cache_dir = os.path.join(base_dir, 'server', 'static', 'data')
 
@@ -180,9 +182,9 @@ def cached_media_with_tag_page(tags_id, max_media_id):
     '''
     We have to do this on the page, not the full list because memcache has a 1MB cache upper limit,
     and some of the collections have TONS of sources
+    Ok to be a cross-user cache here
     '''
-    user_mc = user_mediacloud_client()
-    return user_mc.mediaList(tags_id=tags_id, last_media_id=max_media_id, rows=100)
+    return _media_with_tag_page(tags_id, max_media_id)
 
 
 def _media_with_tag_page(tags_id, max_media_id):

--- a/server/views/sources/__init__.py
+++ b/server/views/sources/__init__.py
@@ -1,13 +1,11 @@
 from server.auth import user_admin_mediacloud_client
 from server.cache import cache, key_generator
 
-SOURCES_TEMPLATE_PROPS_EDIT = ['media_id', 'url', 'name', 'pub_country', 'pub_state', 'primary_language',
-                               'subject_country', 'media_type', 'public_notes', 'is_monitored', 'editor_notes']
+COLLECTIONS_TEMPLATE_METADATA_PROPS = ['pub_country', 'pub_state', 'language', 'about_country', 'media_type']
 
-COLLECTIONS_TEMPLATE_PROPS_EDIT = ['media_id', 'url', 'name', 'pub_country', 'pub_state', 'primary_language',
-                                   'subject_country', 'media_type', 'public_notes', 'is_monitored', 'editor_notes']
-
-COLLECTIONS_TEMPLATE_METADATA_PROPS = ['pub_country', 'pub_state', 'subject_country', 'primary_language', 'media_type']
+COLLECTIONS_TEMPLATE_PROPS_EDIT = ['media_id', 'url', 'name'] + \
+                                  COLLECTIONS_TEMPLATE_METADATA_PROPS +\
+                                  ['public_notes', 'is_monitored', 'editor_notes', 'stories_per_day', 'first_story']
 
 # hand-made whitelist of collections to show up as "featured" on source mgr homepage and in the media picker
 FEATURED_COLLECTION_LIST = [

--- a/server/views/sources/__init__.py
+++ b/server/views/sources/__init__.py
@@ -1,11 +1,10 @@
 from server.auth import user_admin_mediacloud_client
 from server.cache import cache, key_generator
+from server.util.csv import SOURCE_LIST_CSV_METADATA_PROPS
 
-COLLECTIONS_TEMPLATE_METADATA_PROPS = ['pub_country', 'pub_state', 'language', 'about_country', 'media_type']
-
-COLLECTIONS_TEMPLATE_PROPS_EDIT = ['media_id', 'url', 'name'] + \
-                                  COLLECTIONS_TEMPLATE_METADATA_PROPS +\
-                                  ['public_notes', 'is_monitored', 'editor_notes', 'stories_per_day', 'first_story']
+SOURCE_LIST_CSV_EDIT_PROPS = ['media_id', 'url', 'name'] + \
+                             SOURCE_LIST_CSV_METADATA_PROPS + \
+                             ['public_notes', 'is_monitored', 'editor_notes', 'stories_per_day', 'first_story']
 
 # hand-made whitelist of collections to show up as "featured" on source mgr homepage and in the media picker
 FEATURED_COLLECTION_LIST = [

--- a/server/views/sources/collection.py
+++ b/server/views/sources/collection.py
@@ -12,7 +12,7 @@ from server.auth import user_mediacloud_key, user_admin_mediacloud_client, user_
     user_has_auth_role, ROLE_MEDIA_EDIT
 from server.util.request import arguments_required, form_fields_required, api_error_handler
 from server.util.tags import TAG_SETS_ID_COLLECTIONS, is_metadata_tag_set, format_name_from_label, media_with_tag
-from server.views.sources import COLLECTIONS_TEMPLATE_PROPS_EDIT
+from server.views.sources import SOURCE_LIST_CSV_EDIT_PROPS
 from server.views.sources.favorites import add_user_favorite_flag_to_collections, add_user_favorite_flag_to_sources
 from server.views.sources.geocount import stream_geo_csv, cached_geotag_count
 from server.views.sources.stories_split_by_time import stream_split_stories_csv
@@ -187,7 +187,7 @@ def api_collection_sources(collection_id):
 def api_download_sources_template():
     filename = "media cloud collection upload template.csv"
 
-    what_type_download = COLLECTIONS_TEMPLATE_PROPS_EDIT
+    what_type_download = SOURCE_LIST_CSV_EDIT_PROPS
 
     return csv.stream_response(what_type_download, what_type_download, filename)
 
@@ -200,7 +200,7 @@ def api_collection_sources_csv(collection_id):
     collection = user_mc.tag(collection_id)    # not cached because props can change often
     all_media = media_with_tag(user_mediacloud_key(), collection_id)
     file_prefix = "Collection {} ({}) - sources ".format(collection_id, collection['tag'])
-    properties_to_include = COLLECTIONS_TEMPLATE_PROPS_EDIT
+    properties_to_include = SOURCE_LIST_CSV_EDIT_PROPS
     return csv.download_media_csv(all_media, file_prefix, properties_to_include)
 
 

--- a/server/views/sources/collection.py
+++ b/server/views/sources/collection.py
@@ -11,9 +11,8 @@ from server import app, mc, db
 from server.auth import user_mediacloud_key, user_admin_mediacloud_client, user_mediacloud_client, user_name,\
     user_has_auth_role, ROLE_MEDIA_EDIT
 from server.util.request import arguments_required, form_fields_required, api_error_handler
-from server.util.tags import TAG_SETS_ID_COLLECTIONS, is_metadata_tag_set, format_name_from_label, \
-    format_metadata_fields, media_with_tag
-from server.views.sources import SOURCES_TEMPLATE_PROPS_EDIT, COLLECTIONS_TEMPLATE_PROPS_EDIT
+from server.util.tags import TAG_SETS_ID_COLLECTIONS, is_metadata_tag_set, format_name_from_label, media_with_tag
+from server.views.sources import COLLECTIONS_TEMPLATE_PROPS_EDIT
 from server.views.sources.favorites import add_user_favorite_flag_to_collections, add_user_favorite_flag_to_sources
 from server.views.sources.geocount import stream_geo_csv, cached_geotag_count
 from server.views.sources.stories_split_by_time import stream_split_stories_csv
@@ -186,9 +185,9 @@ def api_collection_sources(collection_id):
 @flask_login.login_required
 @api_error_handler
 def api_download_sources_template():
-    filename = "Collection_Template_for_sources.csv"
+    filename = "media cloud collection upload template.csv"
 
-    what_type_download = SOURCES_TEMPLATE_PROPS_EDIT
+    what_type_download = COLLECTIONS_TEMPLATE_PROPS_EDIT
 
     return csv.stream_response(what_type_download, what_type_download, filename)
 
@@ -200,10 +199,6 @@ def api_collection_sources_csv(collection_id):
     user_mc = user_mediacloud_client()
     collection = user_mc.tag(collection_id)    # not cached because props can change often
     all_media = media_with_tag(user_mediacloud_key(), collection_id)
-    for src in all_media:
-        for tag in src['media_source_tags']:
-            if is_metadata_tag_set(tag['tag_sets_id']):
-                format_metadata_fields(src, tag)
     file_prefix = "Collection {} ({}) - sources ".format(collection_id, collection['tag'])
     properties_to_include = COLLECTIONS_TEMPLATE_PROPS_EDIT
     return csv.download_media_csv(all_media, file_prefix, properties_to_include)

--- a/server/views/sources/collectionedit.py
+++ b/server/views/sources/collectionedit.py
@@ -116,7 +116,9 @@ def upload_file():
 
 
 def _parse_sources_from_csv_upload(filepath):
-    acceptable_column_names = SOURCE_LIST_CSV_EDIT_PROPS
+    acceptable_column_names = list(SOURCE_LIST_CSV_EDIT_PROPS)
+    acceptable_column_names.remove('stories_per_day')
+    acceptable_column_names.remove('first_story')
     with open(filepath, 'rU') as f:
         reader = pycsv.DictReader(f)
         reader.fieldnames = acceptable_column_names

--- a/server/views/sources/collectionedit.py
+++ b/server/views/sources/collectionedit.py
@@ -14,7 +14,8 @@ from server.util.config import ConfigException
 from server.auth import user_admin_mediacloud_client, user_mediacloud_key, user_name
 from server.util.request import json_error_response, form_fields_required, api_error_handler
 from server.views.sources.collection import allowed_file
-from server.views.sources import COLLECTIONS_TEMPLATE_PROPS_EDIT, COLLECTIONS_TEMPLATE_METADATA_PROPS
+from server.views.sources import SOURCE_LIST_CSV_EDIT_PROPS
+from server.util.csv import SOURCE_LIST_CSV_METADATA_PROPS
 from server.util.tags import VALID_METADATA_IDS, METADATA_PUB_COUNTRY_NAME, \
     format_name_from_label, tags_in_tag_set, media_with_tag
 
@@ -115,7 +116,7 @@ def upload_file():
 
 
 def _parse_sources_from_csv_upload(filepath):
-    acceptable_column_names = COLLECTIONS_TEMPLATE_PROPS_EDIT
+    acceptable_column_names = SOURCE_LIST_CSV_EDIT_PROPS
     with open(filepath, 'rU') as f:
         reader = pycsv.DictReader(f)
         reader.fieldnames = acceptable_column_names
@@ -156,7 +157,7 @@ def _update_source_worker(source_info):
     media_id = source_info['media_id']
     # logger.debug("Updating media {}".format(media_id))
     source_no_metadata_no_id = {k: v for k, v in source_info.items() if k != 'media_id'
-                         and k not in COLLECTIONS_TEMPLATE_METADATA_PROPS}
+                                and k not in SOURCE_LIST_CSV_METADATA_PROPS}
     response = user_mc.mediaUpdate(media_id, source_no_metadata_no_id)
     return response
 
@@ -189,7 +190,7 @@ def _create_or_update_sources(source_list_from_csv, create_new):
         sources_to_create_no_metadata = []
         for src in sources_to_create:
             sources_to_create_no_metadata.append(
-                {k: v for k, v in src.items() if k not in COLLECTIONS_TEMPLATE_METADATA_PROPS})
+                {k: v for k, v in src.items() if k not in SOURCE_LIST_CSV_METADATA_PROPS})
         # parallelize media creation to make it faster
         chunk_size = 5  # @ 10, each call takes over a minute; @ 5 each takes around ~40 secs
         media_to_create_batches = [sources_to_create_no_metadata[x:x + chunk_size]

--- a/server/views/topics/__init__.py
+++ b/server/views/topics/__init__.py
@@ -1,7 +1,9 @@
 import logging
+import datetime
+
 from server import mc
 from server.auth import is_user_logged_in, user_admin_mediacloud_client
-import datetime
+from server.util.csv import SOURCE_LIST_CSV_METADATA_PROPS
 
 logger = logging.getLogger(__name__)
 
@@ -9,10 +11,12 @@ SORT_FACEBOOK = 'facebook'
 SORT_TWITTER = 'twitter'
 SORT_INLINK = 'inlink'
 
-TOPICS_TEMPLATE_PROPS = ['media_id', 'name', 'url', 'story_count',
-                         'media_inlink_count', 'sum_media_inlink_count', 'inlink_count',
-                         'outlink_count', 'facebook_share_count',
-                         'pub_country', 'pub_state', 'primary_language', 'subject_country']
+TOPIC_MEDIA_INFO_PROPS = ['media_id', 'name', 'url']
+
+TOPIC_MEDIA_PROPS = ['story_count', 'media_inlink_count', 'sum_media_inlink_count', 'inlink_count',
+                     'outlink_count', 'facebook_share_count']
+
+TOPIC_MEDIA_CSV_PROPS = TOPIC_MEDIA_INFO_PROPS + TOPIC_MEDIA_PROPS + SOURCE_LIST_CSV_METADATA_PROPS
 
 
 def validated_sort(desired_sort, default_sort=SORT_FACEBOOK):

--- a/server/views/topics/media.py
+++ b/server/views/topics/media.py
@@ -7,9 +7,8 @@ from server import app, TOOL_API_KEY
 from server.views import WORD_COUNT_DOWNLOAD_LENGTH
 from server.auth import user_mediacloud_key, user_admin_mediacloud_client, is_user_logged_in
 from server.util import csv
-from server.util.tags import is_metadata_tag_set, format_metadata_fields
 from server.views.topics import validated_sort, TOPICS_TEMPLATE_PROPS
-from server.views.topics.splitstories import stream_topic_split_story_counts_csv, topic_split_story_count
+from server.views.topics.splitstories import stream_topic_split_story_counts_csv
 from server.views.topics.stories import stream_story_list_csv
 import server.views.topics.apicache as apicache
 from server.util.request import filters_from_args, api_error_handler
@@ -130,30 +129,17 @@ def media_outlinks_csv(topics_id, media_id):
 def _stream_media_list_csv(user_mc_key, filename, topics_id, **kwargs):
     # Helper method to stream a list of media back to the client as a csv.  Any args you pass in will be
     # simply be passed on to a call to topicMediaList.
-    add_metadata = False  # off for now because this is SUPER slow
     all_media = []
     more_media = True
     params = kwargs
     params['limit'] = 1000  # an arbitrary value to let us page through with big pages
     try:
         cols_to_export = TOPICS_TEMPLATE_PROPS
-        if not add_metadata:
-            cols_to_export = cols_to_export[:-4]    # remove the metadata cols
 
         while more_media:
             page = apicache.topic_media_list(user_mediacloud_key(), topics_id, **params)
             media_list = page['media']
-            user_mc = user_admin_mediacloud_client()
-
-            if add_metadata:
-                for media_item in media_list:
-                    media_info = user_mc.media(media_item['media_id'])
-                    for eachItem in media_info['media_source_tags']:
-                        if is_metadata_tag_set(eachItem['tag_sets_id']):
-                            format_metadata_fields(media_item, eachItem)
-
             all_media = all_media + media_list
-
             if 'next' in page['link_ids']:
                 params['link_id'] = page['link_ids']['next']
                 more_media = True

--- a/server/views/topics/media.py
+++ b/server/views/topics/media.py
@@ -7,8 +7,9 @@ from server import app, TOOL_API_KEY
 from server.views import WORD_COUNT_DOWNLOAD_LENGTH
 from server.auth import user_mediacloud_key, user_admin_mediacloud_client, is_user_logged_in
 from server.util import csv
-from server.views.topics import validated_sort, TOPICS_TEMPLATE_PROPS
-from server.views.topics.splitstories import stream_topic_split_story_counts_csv
+from server.util.tags import is_metadata_tag_set, label_for_metadata_tag
+from server.views.topics import validated_sort, TOPIC_MEDIA_CSV_PROPS
+from server.views.topics.splitstories import stream_topic_split_story_counts_csv, topic_split_story_count
 from server.views.topics.stories import stream_story_list_csv
 import server.views.topics.apicache as apicache
 from server.util.request import filters_from_args, api_error_handler
@@ -126,20 +127,34 @@ def media_outlinks_csv(topics_id, media_id):
                                  link_from_media_id=media_id, timespans_id=timespans_id, q=q)
 
 
+def _media_info_worker(media_topic_data):
+    media_info = apicache.get_media(media_topic_data['media_id'])
+    media_topic_data.update(media_info)
+    return media_topic_data
+
+
 def _stream_media_list_csv(user_mc_key, filename, topics_id, **kwargs):
     # Helper method to stream a list of media back to the client as a csv.  Any args you pass in will be
     # simply be passed on to a call to topicMediaList.
+    add_metadata = False  # off for now because this is SUPER slow
     all_media = []
     more_media = True
     params = kwargs
     params['limit'] = 1000  # an arbitrary value to let us page through with big pages
     try:
-        cols_to_export = TOPICS_TEMPLATE_PROPS
+        cols_to_export = TOPIC_MEDIA_CSV_PROPS
+        if not add_metadata:
+            cols_to_export = cols_to_export[:-4]    # remove the metadata cols
 
         while more_media:
             page = apicache.topic_media_list(user_mediacloud_key(), topics_id, **params)
             media_list = page['media']
+
+            if add_metadata:
+                media_list = [_media_info_worker(m) for m in media_list]
+
             all_media = all_media + media_list
+
             if 'next' in page['link_ids']:
                 params['link_id'] = page['link_ids']['next']
                 more_media = True

--- a/server/views/topics/media.py
+++ b/server/views/topics/media.py
@@ -7,9 +7,8 @@ from server import app, TOOL_API_KEY
 from server.views import WORD_COUNT_DOWNLOAD_LENGTH
 from server.auth import user_mediacloud_key, user_admin_mediacloud_client, is_user_logged_in
 from server.util import csv
-from server.util.tags import is_metadata_tag_set, label_for_metadata_tag
 from server.views.topics import validated_sort, TOPIC_MEDIA_CSV_PROPS
-from server.views.topics.splitstories import stream_topic_split_story_counts_csv, topic_split_story_count
+from server.views.topics.splitstories import stream_topic_split_story_counts_csv
 from server.views.topics.stories import stream_story_list_csv
 import server.views.topics.apicache as apicache
 from server.util.request import filters_from_args, api_error_handler


### PR DESCRIPTION
This tries to centralize the creation of source list CSVs (based on errors Anushka found).  Specifically, it uses the new `metadata` property that the API client adds to `mediaList` calls.  This lets us avoid having to walk through and parse the tags in the code here, because it does it for us in the API client code. I've also renamed some of the constants to more clearly indicate that they are lists of columns for CSV downloads/uploads.  

(Still waiting for https://github.com/berkmancenter/mediacloud/issues/190 to be resolved before we can treat media list calls in Topic Mapper the same way)