### PR TITLE
Rename "feed_status" to "active" boolean, "feed_type" to "type"

### DIFF
--- a/server/views/sources/collection.py
+++ b/server/views/sources/collection.py
@@ -146,7 +146,7 @@ def _media_list_edit_worker(media_id):
         latest_scrape_job = scrape_jobs['job_states'][0]
     # active feed count
     feeds = user_mc.feedList(media_id)
-    active_syndicated_feeds = [f for f in feeds if f['active'] and f['feed_type'] == 'syndicated']
+    active_syndicated_feeds = [f for f in feeds if f['active'] and f['type'] == 'syndicated']
     active_feed_count = len(active_syndicated_feeds)
     return {
         'media_id': media_id,

--- a/server/views/sources/collection.py
+++ b/server/views/sources/collection.py
@@ -146,7 +146,7 @@ def _media_list_edit_worker(media_id):
         latest_scrape_job = scrape_jobs['job_states'][0]
     # active feed count
     feeds = user_mc.feedList(media_id)
-    active_syndicated_feeds = [f for f in feeds if f['feed_status'] == 'active' and f['feed_type'] == 'syndicated']
+    active_syndicated_feeds = [f for f in feeds if f['active'] and f['feed_type'] == 'syndicated']
     active_feed_count = len(active_syndicated_feeds)
     return {
         'media_id': media_id,

--- a/server/views/sources/feeds.py
+++ b/server/views/sources/feeds.py
@@ -43,9 +43,9 @@ def feed_create(media_id):
     name = request.form['name']
     url = request.form['url']
     feed_type = request.form['feed_type'] if 'feed_type' in request.form else None  # this is optional
-    feed_status = request.form['feed_status'] if 'feed_status' in request.form else None  # this is optional
+    active = request.form['active'] if 'active' in request.form else None  # this is optional
 
-    result = user_mc.feedCreate(media_id, name, url, feed_type, feed_status)
+    result = user_mc.feedCreate(media_id, name, url, feed_type, active)
     return jsonify(result)
 
 
@@ -57,9 +57,9 @@ def feed_update(feed_id):
     name = request.form['name']
     url = request.form['url']
     feed_type = request.form['feed_type'] if 'feed_type' in request.form else None  # this is optional
-    feed_status = request.form['feed_status'] if 'feed_status' in request.form else None  # this is optional
+    active = request.form['active'] if 'active' in request.form else None  # this is optional
 
-    result = user_mc.feedUpdate(feeds_id=feed_id, name=name, url=url, feed_type=feed_type, feed_status=feed_status)
+    result = user_mc.feedUpdate(feeds_id=feed_id, name=name, url=url, feed_type=feed_type, active=active)
     return jsonify(result)
 
 

--- a/server/views/sources/feeds.py
+++ b/server/views/sources/feeds.py
@@ -42,7 +42,7 @@ def feed_create(media_id):
     user_mc = user_admin_mediacloud_client()
     name = request.form['name']
     url = request.form['url']
-    feed_type = request.form['feed_type'] if 'feed_type' in request.form else None  # this is optional
+    feed_type = request.form['type'] if 'type' in request.form else None  # this is optional
     active = request.form['active'] if 'active' in request.form else None  # this is optional
 
     result = user_mc.feedCreate(media_id, name, url, feed_type, active)
@@ -56,7 +56,7 @@ def feed_update(feed_id):
     user_mc = user_admin_mediacloud_client()
     name = request.form['name']
     url = request.form['url']
-    feed_type = request.form['feed_type'] if 'feed_type' in request.form else None  # this is optional
+    feed_type = request.form['type'] if 'type' in request.form else None  # this is optional
     active = request.form['active'] if 'active' in request.form else None  # this is optional
 
     result = user_mc.feedUpdate(feeds_id=feed_id, name=name, url=url, feed_type=feed_type, active=active)
@@ -83,7 +83,7 @@ def source_feed_list_page(media_id, max_feed_id):
 
 def stream_feed_csv(filename, media_id):
     response = cached_feed(media_id)
-    props = ['name', 'feed_type', 'url']
+    props = ['name', 'type', 'url']
     return csv.stream_response(response, props, filename)
 
 

--- a/src/components/source/SourceFeedTable.js
+++ b/src/components/source/SourceFeedTable.js
@@ -32,7 +32,7 @@ const SourceFeedTable = (props) => {
                 {feed.name}
               </td>
               <td>
-                {feed.feed_type}
+                {feed.type}
               </td>
               <td>
                 {feed.active ? 'active' : 'disabled'}

--- a/src/components/source/SourceFeedTable.js
+++ b/src/components/source/SourceFeedTable.js
@@ -23,11 +23,11 @@ const SourceFeedTable = (props) => {
           <tr>
             <th><FormattedMessage {...messages.feedName} /></th>
             <th><FormattedMessage {...messages.feedType} /></th>
-            <th><FormattedMessage {...messages.feedStatus} /></th>
+            <th><FormattedMessage {...messages.feedIsActive} /></th>
             <th><FormattedMessage {...messages.feedUrl} /></th>
           </tr>
           {feeds.map((feed, idx) =>
-            (<tr key={feed.feeds_id} className={`${(idx % 2 === 0) ? 'even' : 'odd'} feed-${feed.feed_status}`}>
+            (<tr key={feed.feeds_id} className={`${(idx % 2 === 0) ? 'even' : 'odd'} feed-${(feed.active) ? 'active' : 'disabled'}`}>
               <td>
                 {feed.name}
               </td>
@@ -35,7 +35,7 @@ const SourceFeedTable = (props) => {
                 {feed.feed_type}
               </td>
               <td>
-                {feed.feed_status === 'active' ? 'active' : 'disabled'}
+                {feed.active ? 'active' : 'disabled'}
               </td>
               <td>
                 <a href={feed.url}>{feed.url}</a>

--- a/src/components/source/mediaSource/CreateSourceFeedContainer.js
+++ b/src/components/source/mediaSource/CreateSourceFeedContainer.js
@@ -45,7 +45,7 @@ const CreateSourceFeedContainer = (props) => {
       </h2>
       <SourceFeedForm
         initialValues={{
-          feed_type: 'syndicated',
+          type: 'syndicated',
           active: true,
         }}
         onSave={handleSave}
@@ -83,7 +83,7 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
       name: values.name,
       url: values.url,
       active: values.active,
-      feed_type: values.feed_type,
+      type: values.type,
     };
     dispatch(createFeed(ownProps.params.sourceId, infoToSave))
       .then((result) => {

--- a/src/components/source/mediaSource/CreateSourceFeedContainer.js
+++ b/src/components/source/mediaSource/CreateSourceFeedContainer.js
@@ -46,7 +46,7 @@ const CreateSourceFeedContainer = (props) => {
       <SourceFeedForm
         initialValues={{
           feed_type: 'syndicated',
-          feed_status: 'active',
+          active: true,
         }}
         onSave={handleSave}
         sourceName={sourceName}
@@ -82,7 +82,7 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
     const infoToSave = {
       name: values.name,
       url: values.url,
-      feed_status: values.feed_status,
+      active: values.active,
       feed_type: values.feed_type,
     };
     dispatch(createFeed(ownProps.params.sourceId, infoToSave))

--- a/src/components/source/mediaSource/EditSourceFeedContainer.js
+++ b/src/components/source/mediaSource/EditSourceFeedContainer.js
@@ -101,7 +101,7 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
     const infoToSave = {
       name: values.name,
       url: values.url,
-      feed_status: values.binaryFeedStatus === 'active' ? 'active' : 'inactive',
+      active: values.active,
       feed_type: values.feed_type,
     };
     dispatch(updateFeed(ownProps.params.feedId, infoToSave))

--- a/src/components/source/mediaSource/EditSourceFeedContainer.js
+++ b/src/components/source/mediaSource/EditSourceFeedContainer.js
@@ -102,7 +102,7 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
       name: values.name,
       url: values.url,
       active: values.active,
-      feed_type: values.feed_type,
+      type: values.type,
     };
     dispatch(updateFeed(ownProps.params.feedId, infoToSave))
       .then((result) => {

--- a/src/components/source/mediaSource/form/SourceFeedForm.js
+++ b/src/components/source/mediaSource/form/SourceFeedForm.js
@@ -12,8 +12,7 @@ import messages from '../../../../resources/messages';
 const localMessages = {
   typeSyndicated: { id: 'source.feed.add.type.syndicated', defaultMessage: 'Syndicated' },
   typeWebPage: { id: 'source.feed.add.type.webpage', defaultMessage: 'Web Page' },
-  statusActive: { id: 'source.feed.add.status.active', defaultMessage: 'Active' },
-  statusDisabled: { id: 'source.feed.add.status.inactive', defaultMessage: 'Disabled' },
+  feedIsActive: { id: 'source.feed.add.active', defaultMessage: 'Feed is Active' },
   urlInvalid: { id: 'source.feed.url.invalid', defaultMessage: 'That isn\'t a valid feed URL. Please enter just the full url of one RSS or Atom feed.' },
 };
 
@@ -66,14 +65,17 @@ const SourceFeedForm = (props) => {
       <Row>
         <Col md={2}>
           <span className="label unlabeled-field-label">
-            <FormattedMessage {...messages.feedStatus} />
+            <FormattedMessage {...messages.feedIsActive} />
           </span>
         </Col>
         <Col md={8}>
-          <Field name="binaryFeedStatus" value="active" component={renderSelectField} >
-            <MenuItem value="active" primaryText={formatMessage(localMessages.statusActive)} />
-            <MenuItem value="disabled" primaryText={formatMessage(localMessages.statusDisabled)} />
-          </Field>
+          <Field
+            name="active"
+            component={renderCheckbox}
+            fullWidth
+            label={formatMessage(messages.feedIsActive)}
+            value=true
+          />
         </Col>
       </Row>
       <AppButton
@@ -102,9 +104,6 @@ SourceFeedForm.propTypes = {
 
 function validate(values) {
   const errors = {};
-  if (emptyString(values.binaryFeedStatus)) {
-    errors.feed_status = messages.required;
-  }
   if (emptyString(values.feed_type)) {
     errors.feed_type = messages.required;
   }

--- a/src/components/source/mediaSource/form/SourceFeedForm.js
+++ b/src/components/source/mediaSource/form/SourceFeedForm.js
@@ -56,7 +56,7 @@ const SourceFeedForm = (props) => {
           </span>
         </Col>
         <Col md={8}>
-          <Field name="feed_type" component={renderSelectField} >
+          <Field name="type" component={renderSelectField} >
             <MenuItem key="syndicated" value="syndicated" primaryText={formatMessage(localMessages.typeSyndicated)} />
             <MenuItem key="web_page" value="web_page" primaryText={formatMessage(localMessages.typeWebPage)} />
           </Field>
@@ -104,8 +104,8 @@ SourceFeedForm.propTypes = {
 
 function validate(values) {
   const errors = {};
-  if (emptyString(values.feed_type)) {
-    errors.feed_type = messages.required;
+  if (emptyString(values.type)) {
+    errors.type = messages.required;
   }
   if (emptyString(values.url)) {
     errors.url = messages.required;

--- a/src/lib/serverApi/sources.js
+++ b/src/lib/serverApi/sources.js
@@ -164,12 +164,12 @@ export function sourceFeed(mediaId, feedId) {
 }
 
 export function createFeed(mediaId, params) {
-  const acceptedParams = acceptParams(params, ['name', 'url', 'feed_type', 'active']);
+  const acceptedParams = acceptParams(params, ['name', 'url', 'type', 'active']);
   return createPostingApiPromise(`/api/sources/${mediaId}/feeds/create`, acceptedParams);
 }
 
 export function updateFeed(feedId, params) {
-  const acceptedParams = acceptParams(params, ['name', 'url', 'feed_type', 'active']);
+  const acceptedParams = acceptParams(params, ['name', 'url', 'type', 'active']);
   return createPostingApiPromise(`/api/sources/feeds/${feedId}/update`, acceptedParams);
 }
 

--- a/src/lib/serverApi/sources.js
+++ b/src/lib/serverApi/sources.js
@@ -164,12 +164,12 @@ export function sourceFeed(mediaId, feedId) {
 }
 
 export function createFeed(mediaId, params) {
-  const acceptedParams = acceptParams(params, ['name', 'url', 'feed_type', 'feed_status']);
+  const acceptedParams = acceptParams(params, ['name', 'url', 'feed_type', 'active']);
   return createPostingApiPromise(`/api/sources/${mediaId}/feeds/create`, acceptedParams);
 }
 
 export function updateFeed(feedId, params) {
-  const acceptedParams = acceptParams(params, ['name', 'url', 'feed_type', 'feed_status']);
+  const acceptedParams = acceptParams(params, ['name', 'url', 'feed_type', 'active']);
   return createPostingApiPromise(`/api/sources/feeds/${feedId}/update`, acceptedParams);
 }
 

--- a/src/reducers/sources/sources/selected/feed/info.js
+++ b/src/reducers/sources/sources/selected/feed/info.js
@@ -10,7 +10,7 @@ const feeds = createAsyncReducer({
   action: FETCH_SOURCE_FEED,
   handleSuccess: payload => ({
     sourceId: payload.feed.media_id,
-    feed: Object.assign({}, payload.feed, { binaryFeedStatus: payload.feed.feed_status === 'active' ? 'active' : 'disabled' }),
+    feed: Object.assign({}, payload.feed, { active: payload.feed.active }),
     feedId: payload.feeds_id,
   }),
   [SELECT_SOURCE_FEED]: payload => ({

--- a/src/resources/messages.js
+++ b/src/resources/messages.js
@@ -66,7 +66,7 @@ const messages = {
   feedName: { id: 'feed.name', defaultMessage: 'Name' },
   feedUrl: { id: 'feed.url', defaultMessage: 'URL' },
   feedType: { id: 'feed.type', defaultMessage: 'Type' },
-  feedStatus: { id: 'feed.status', defaultMessage: 'Status' },
+  feedIsActive: { id: 'feed.active', defaultMessage: 'Active' },
 
   timespan: { id: 'common.timespan', defaultMessage: 'Timespan' },
 

--- a/src/styles/sources/_feed_table.scss
+++ b/src/styles/sources/_feed_table.scss
@@ -4,13 +4,10 @@
   margin-top: 20px;
   
   tr {
-    &.feed-inactive {
-      background-color: $material-grey500;
-    }
-    &.feed-skipped {
-      background-color: $material-grey500;
-    }
     &.feed-active {
+    }
+    &.feed-disabled {
+      background-color: $material-grey500;
     }
   }
 


### PR DESCRIPTION
Hi again Cindy & Rahul,

As part of our cleanup (https://github.com/berkmancenter/mediacloud/issues/416), we want to:

1. Rename `feed_status` API JSON response field to `active` boolean, and
2. Rename `feed_type` API JSON response field to `type`.

*Before:*

```json
{
    "feed_status": "active",
    "feed_type": "syndicated"
}
```

*After:*

```json
{
    "active": true,
    "type": "syndicated"
}
```

(Admittedly I didn't even test those changes by running them because I'm not much of a frontender, those commits are basically just a careful find-and-replace, so I would be thankful if you could have a hard look into them.)

As detailed in https://github.com/berkmancenter/mediacloud/pull/421, could you:

1. Wait for us to release said PR (https://github.com/berkmancenter/mediacloud/pull/421),
2. Review, merge & deploy this PR on your end,
3. Let us know when you did so?
