### PR TITLE
Increase worker timeout to 1 minute to allow large CSV downloads

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: gunicorn server:app
+web: gunicorn server:app -k gevent
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,5 @@ gunicorn==19.9.0
 dogpile.cache==0.6.7
 python-dateutil==2.7.3
 python-slugify==1.2.6
+greenlet==0.4.15
+gevent==1.3.7

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,1 @@
-source venv/bin/activate
-
-# Workers might stall for a while on slower API requests
-WORKER_TIMEOUT=60
-
-gunicorn --timeout=$WORKER_TIMEOUT server:app
-
+gunicorn server:app -k gevent

--- a/run.sh
+++ b/run.sh
@@ -1,2 +1,7 @@
 source venv/bin/activate
-gunicorn server:app
+
+# Workers might stall for a while on slower API requests
+WORKER_TIMEOUT=60
+
+gunicorn --timeout=$WORKER_TIMEOUT server:app
+


### PR DESCRIPTION
Large CSV downloads time out with network error for Anushka, e.g. from URL:

```
https://explorer.mediacloud.org/#/queries/search?q=[{%22label%22:%22Diseases%22,%22q%22:%22(diarrhea%20OR%20rota%20OR%20rotavirus)%20OR%20(hiv%20OR%20aids%20OR%20avahan%20OR%20naco%20OR%20antiretroviral)%20OR%20(malaria*)%20OR%20(pneumonia%20OR%20%22pneumococcal%20vaccine%22)%20OR%20(tuberculosis%20OR%20tb%20OR%20%22bcg%20vaccine%22)%20OR%20(polio%20OR%20IPV%20OR%20(OPV%20-ship%20-vessel%20-navy))%20OR%20(%22visceral%20leishmaniasis%22%20OR%20typhoid%20OR%20%20%22Lymphatic%20Filariasis%22%20OR%20Elephantiasis%20OR%20NTDs%20OR%20%22infectious%20disease%22%20OR%20%22infectious%20diseases%22%20OR%20%22Mass%20drug%20administration%22%20OR%20%22kala%20azar%22%20OR%20%22sandfly%22%20OR%20%22Acute%20Encephalitis%20Syndrome%22%20OR%20AES%20OR%20%22neglected%20tropical%20disease%22%20OR%20%22neglected%20tropical%20diseases%22)%22,%22color%22:%22%231f77b4%22,%22startDate%22:%222017-01-01%22,%22endDate%22:%222018-07-01%22,%22sources%22:[],%22collections%22:[34412118]}]
```

Dokku container on mcservices1 proceeds happily with API requests up until it suddenly times out, leading to a dropped connection:

```
...
[08:58:50][DEBUG] mediacloud.api api.py:_query:458 | query GET to https://api.mediacloud.org/api/v2/stories/list with {'q': u'((diarrhea OR rota OR rotavirus) OR (hiv OR aids OR avahan OR naco OR antiretroviral) OR (malaria*) OR (pneumonia OR "pneumococcal vaccine") OR (tuberculosis OR tb OR "bcg vaccine") OR (polio OR IPV OR (OPV -ship -vessel -navy)) OR ("visceral leishmaniasis" OR typhoid OR  "Lymphatic Filariasis" OR Elephantiasis OR NTDs OR "infectious disease" OR "infectious diseases" OR "Mass drug administration" OR "kala azar" OR "sandfly" OR "Acute Encephalitis Syndrome" OR AES OR "neglected tropical disease" OR "neglected tropical diseases")) AND (( tags_id_media:(34412118)))', 'sentences': 0, 'text': 0, 'show_feeds': 0, 'fq': 'publish_day:[2017-01-01T00:00:00Z TO 2018-07-01T00:00:00Z]', 'sort': 'processed_stories_id', 'wc': 0, 'corenlp': 0, 'ap_stories_id': 0, 'last_processed_stories_id': 1375734979, 'rows': 500, 'feeds_id': None, 'raw_1st_download': 0} and None
[2018-10-23 08:58:50 +0000] [12] [CRITICAL] WORKER TIMEOUT (pid:516)
[2018-10-23 08:58:51 +0000] [592] [INFO] Booting worker with pid: 592
```

From the logs, it seems that worker is happily returning something up until it attempts to run some large and slow `stories/list` API calls, then it ends up not returning anything for a while to the client and so Gunicorn decides that it's dead.

Increasing the worker timeout is just a nasty hack (and might backfire in weird ways), but it might just work as a temporary workaround. A better architectural fix on our end would probably be to stop providing API calls which falsely claim that they're able to return **Everything** (a lot of rows with a lot of fields) in a timely manner :)