### PR TITLE
serialize explorer queries to url with JSON

### DIFF
--- a/src/components/explorer/UrlBasedQueryContainer.js
+++ b/src/components/explorer/UrlBasedQueryContainer.js
@@ -10,7 +10,8 @@ import { LEVEL_ERROR } from '../common/Notice';
 import { addNotice } from '../../actions/appActions';
 import { selectBySearchParams, fetchSampleSearches, updateQuerySourceLookupInfo, updateQueryCollectionLookupInfo,
   fetchQuerySourcesByIds, fetchQueryCollectionsByIds, demoQuerySourcesByIds, demoQueryCollectionsByIds } from '../../actions/explorerActions';
-import { DEFAULT_COLLECTION_OBJECT_ARRAY, autoMagicQueryLabel, generateQueryParamString, decodeQueryParamString } from '../../lib/explorerUtil';
+import { DEFAULT_COLLECTION_OBJECT_ARRAY, autoMagicQueryLabel, generateQueryParamString,
+  decodeQueryParamString, serializeQueriesForUrl } from '../../lib/explorerUtil';
 import { getDateRange, solrFormat, PAST_MONTH } from '../../lib/dateUtil';
 import { notEmptyString } from '../../lib/formValidators';
 
@@ -66,30 +67,62 @@ function composeUrlBasedQueryContainer() {
       }
 
       updateQueriesFromLocation(location, autoName) {
+        // read the URL and decide how to update the queries in the store
+        const { addAppNotice } = this.props;
+        const { formatMessage } = this.props.intl;
         // regular searches are in a queryParam, but samples by id are part of the path
         const url = location.pathname;
         const lastPathPart = url.slice(url.lastIndexOf('/') + 1, url.length);
         const sampleNumber = parseInt(lastPathPart, 10);
         if (!Number.isNaN(sampleNumber)) {
           this.updateQueriesFromSampleId(sampleNumber);
-        } else {
+        } else if (location.query.q) {
           // this is a crazy fix to make embedded quotes work by forcing us to escape them all... partially because
           // react-router decided to decode url components, partially because the JSON parser isn't that clever
-          const text = location.query.q;
-          const pattern = /:"([^,]*)"[,}]/g; // gotta end with , or } here to support demo case (})
-          let match = pattern.exec(text);
-          let cleanedText = '';
-          let lastSpot = 0;
-          while (match != null) {
-            const matchText = text.substring(match.index + 2, pattern.lastIndex - 2);
-            const cleanedMatch = matchText.replace(/"/g, '\\"');
-            cleanedText += `${text.substring(lastSpot, match.index)}:"${cleanedMatch}`;
-            lastSpot = pattern.lastIndex - 2;
-            match = pattern.exec(text);
-          }
-          cleanedText += text.substring(lastSpot, text.length);
-          // now that we have a relatively clean url, lets use it!
-          this.updateQueriesFromString(cleanedText, autoName);
+          this.updateQueriesFromQParam(location.query.q, autoName);
+        } else if (location.query.qs) {
+          this.updateQueriesFromQSParam(location.query.qs, autoName);
+        } else {
+          addAppNotice({ level: LEVEL_ERROR, message: formatMessage(localMessages.errorInURLParams) });
+        }
+      }
+
+      updateQueriesFromQSParam(queryString, autoName) {
+        // the newer, fully serialized way we are supporing going forward
+        const { formatMessage } = this.props.intl;
+        const { addAppNotice } = this.props;
+        try {
+          const queriesFromUrl = JSON.parse(queryString);
+          this.updateQueriesFromString(queriesFromUrl, autoName);
+        } catch (f) {
+          addAppNotice({ level: LEVEL_ERROR, message: formatMessage(localMessages.errorInURLParams) });
+        }
+      }
+
+      updateQueriesFromQParam(queryString, autoName) {
+        const { addAppNotice } = this.props;
+        const { formatMessage } = this.props.intl;
+        // the older, "ugly" way that we are deprecating
+        const text = queryString;
+        const pattern = /:"([^,]*)"[,}]/g; // gotta end with , or } here to support demo case (})
+        let match = pattern.exec(text);
+        let cleanedText = '';
+        let lastSpot = 0;
+        while (match != null) {
+          const matchText = text.substring(match.index + 2, pattern.lastIndex - 2);
+          const cleanedMatch = matchText.replace(/"/g, '\\"');
+          cleanedText += `${text.substring(lastSpot, match.index)}:"${cleanedMatch}`;
+          lastSpot = pattern.lastIndex - 2;
+          match = pattern.exec(text);
+        }
+        cleanedText += text.substring(lastSpot, text.length);
+        // now that we have a relatively clean url, lets use it!
+        try {
+          const queriesFromUrl = decodeQueryParamString(decodeURIComponent(cleanedText));
+          // and update the queries
+          this.updateQueriesFromString(queriesFromUrl, autoName);
+        } catch (f) {
+          addAppNotice({ level: LEVEL_ERROR, message: formatMessage(localMessages.errorInURLParams) });
         }
       }
 
@@ -100,18 +133,8 @@ function composeUrlBasedQueryContainer() {
         saveQueriesFromParsedUrl(queriesFromUrl, isLoggedIn);
       }
 
-      updateQueriesFromString(queryAsJsonStr, autoNaming) {
-        const { addAppNotice, saveQueriesFromParsedUrl, isLoggedIn } = this.props;
-        const { formatMessage } = this.props.intl;
-        let queriesFromUrl;
-
-        try {
-          queriesFromUrl = decodeQueryParamString(decodeURIComponent(queryAsJsonStr));
-        } catch (f) {
-          addAppNotice({ level: LEVEL_ERROR, message: formatMessage(localMessages.errorInURLParams) });
-          return;
-        }
-
+      updateQueriesFromString(queriesFromUrl, autoNaming) {
+        const { saveQueriesFromParsedUrl, isLoggedIn } = this.props;
         let extraDefaults = {};
         // add in an index, label, and color if they are not there
         if (!isLoggedIn) { // and demo mode needs some extra stuff too
@@ -125,7 +148,7 @@ function composeUrlBasedQueryContainer() {
         } else {
           extraDefaults = { autoNaming };
         }
-        queriesFromUrl = queriesFromUrl.map((query, index) => ({
+        const cleanedQueries = queriesFromUrl.map((query, index) => ({
           ...query, // let anything on URL override label and color
           label: notEmptyString(query.label) ? query.label : autoMagicQueryLabel(query),
           // remember demo queries won't have sources or collections on the URL
@@ -137,7 +160,7 @@ function composeUrlBasedQueryContainer() {
           ...extraDefaults, // for demo mode
         }));
         // push the queries in to the store
-        saveQueriesFromParsedUrl(queriesFromUrl, isLoggedIn);
+        saveQueriesFromParsedUrl(cleanedQueries, isLoggedIn);
       }
 
       isAllMediaDetailsReady() {
@@ -232,10 +255,10 @@ function composeUrlBasedQueryContainer() {
         const unDeletedQueries = queries.filter(q => q.deleted !== true);
         const nonEmptyQueries = unDeletedQueries.filter(q => q.q !== undefined && q.q !== '');
         if (!isLoggedIn) {
-          const urlParamString = nonEmptyQueries.map((q, idx) => `{"index":${idx},"q":"${encodeURIComponent(q.q)}","color":"${encodeURIComponent(q.color)}"}`);
-          dispatch(push({ pathname: '/queries/demo/search', search: `?q=[${urlParamString}]` }));
+          const queriesToSerialize = nonEmptyQueries.map((q, idx) => ({ index: idx, q: q.q, color: q.color }));
+          dispatch(push({ pathname: '/queries/demo/search', search: `?qs=${serializeQueriesForUrl(queriesToSerialize)}` }));
         } else {
-          const search = generateQueryParamString(queries.map(q => ({
+          const queriesToSerialize = generateQueryParamString(queries.map(q => ({
             label: q.label,
             q: q.q,
             color: q.color,
@@ -244,7 +267,7 @@ function composeUrlBasedQueryContainer() {
             sources: q.sources, // de-aggregate media bucket into sources and collections
             collections: q.collections,
           })));
-          dispatch(push({ pathname: '/queries/search', search: `?q=${search}` })); // query adds a '?query='
+          dispatch(push({ pathname: '/queries/search', search: `?qs=${serializeQueriesForUrl(queriesToSerialize)}` }));
         }
       },
     });

--- a/src/components/explorer/home/Homepage.js
+++ b/src/components/explorer/home/Homepage.js
@@ -11,7 +11,7 @@ import SearchForm from './SearchForm';
 import SampleSearchContainer from './SampleSearchContainer';
 import { getDateRange, solrFormat, PAST_MONTH } from '../../../lib/dateUtil';
 import { getUserRoles, hasPermissions, PERMISSION_LOGGED_IN } from '../../../lib/auth';
-import { DEFAULT_COLLECTION_OBJECT_ARRAY, generateQueryParamString, autoMagicQueryLabel } from '../../../lib/explorerUtil';
+import { DEFAULT_COLLECTION, autoMagicQueryLabel, serializeQueriesForUrl } from '../../../lib/explorerUtil';
 import { emptyString } from '../../../lib/formValidators';
 import ExplorerMarketingFeatureList from './ExplorerMarketingFeatureList';
 import SystemStatsContainer from '../../common/statbar/SystemStatsContainer';
@@ -99,15 +99,14 @@ const mapDispatchToProps = dispatch => ({
         startDate: solrFormat(defaultDates.start),
         endDate: solrFormat(defaultDates.end),
         color: schemeCategory10[0],
-        collections: DEFAULT_COLLECTION_OBJECT_ARRAY,
+        collections: [DEFAULT_COLLECTION],
         sources: [],
       }];
       queries[0].label = autoMagicQueryLabel(queries[0]);
-      const queryStr = generateQueryParamString(queries);
-      urlParamString = `search?q=${queryStr}`;
+      urlParamString = `search?qs=${serializeQueriesForUrl(queries)}`;
     } else {
-      const queryStr = `[{"q":"${encodeURIComponent(keyword)}"}]`;
-      urlParamString = `demo/search?q=${queryStr}`;
+      const queries = [{ q: keyword }];
+      urlParamString = `demo/search?qs=${serializeQueriesForUrl(queries)}`;
     }
     dispatch(push(`/queries/${urlParamString}&auto=true`));
   },

--- a/src/lib/explorerUtil.js
+++ b/src/lib/explorerUtil.js
@@ -31,6 +31,10 @@ export const DATES = ['startDate', 'endDate'];
 export const LEFT = 0;
 export const RIGHT = 1;
 
+export function serializeQueriesForUrl(queries) {
+  return encodeURIComponent(JSON.stringify(queries));
+}
+
 export function generateQueryParamObject(query, skipEncoding) {
   return {
     label: skipEncoding ? query.label : encodeURIComponent(query.label),


### PR DESCRIPTION
Our current query serialization is very brittle; it was built to support readable explorer URLs so people could edit them by hand.  Turns out this isn't a feature anybody uses.  To fix this, I've added a new `qs` param that serializes all the query info via simple calls to JSON; no fancy encoding on each field.  This makes our URL serialization code far more robust on the client side, and reduces code complexity.

Except that we have to be backwards compatible with the current `q` param.  So I set it up so any new queries use the `qs` approach, while old queries with `q` still work.

Future work would clean up the URL serialization we use to send stuff to the server via async calls, and  would transform incoming `q`-based requests to be reloaded as `qs` ones, further isolating that old code.