### PR TITLE
stop processing after a 400 error

### DIFF
--- a/src/components/common/hocs/AsyncContainer.js
+++ b/src/components/common/hocs/AsyncContainer.js
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import ErrorTryAgain from '../ErrorTryAgain';
 import LoadingSpinner from '../LoadingSpinner';
-import ErrorBoundary from '../ErrorBoundary';
 import * as fetchConstants from '../../../lib/fetchConstants';
 
 // pass this in as the second arg to not show a spinner
@@ -73,9 +72,6 @@ export const asyncContainerize = (ChildComponent, loadingSpinnerSize) => {
           case fetchConstants.FETCH_FAILED:
             content = (
               <div className="async-loading">
-                <ErrorBoundary>
-                  <ChildComponent {...this.props} />
-                </ErrorBoundary>
                 <div className="loading-overlay">
                   <div className="overlay-content">
                     <ErrorTryAgain onTryAgain={asyncFetch} />

--- a/src/components/common/hocs/AsyncContainer.js
+++ b/src/components/common/hocs/AsyncContainer.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import ErrorTryAgain from '../ErrorTryAgain';
 import LoadingSpinner from '../LoadingSpinner';
+import ErrorBoundary from '../ErrorBoundary';
 import * as fetchConstants from '../../../lib/fetchConstants';
 
 // pass this in as the second arg to not show a spinner
@@ -72,7 +73,9 @@ export const asyncContainerize = (ChildComponent, loadingSpinnerSize) => {
           case fetchConstants.FETCH_FAILED:
             content = (
               <div className="async-loading">
-                <ChildComponent {...this.props} />
+                <ErrorBoundary>
+                  <ChildComponent {...this.props} />
+                </ErrorBoundary>
                 <div className="loading-overlay">
                   <div className="overlay-content">
                     <ErrorTryAgain onTryAgain={asyncFetch} />


### PR DESCRIPTION
With this change, anything other than a HTTP 200 (OK) kills the action chain, and shows an error at a much lower widget level (rather than killing the whole UI) - via an `<ErrorBoundary>`. 

I'm a little nervous about the change to have the ErrorBoundary at a lower level (ie. around every single async widget), but I think it might help us fail more gracefully. Your thought?