### PR TITLE
Update all page titles with new helper

### DIFF
--- a/src/components/PageNotFound.js
+++ b/src/components/PageNotFound.js
@@ -1,34 +1,29 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Helmet } from 'react-helmet';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import { Grid, Row, Col } from 'react-flexbox-grid/lib';
+import PageTitle from './common/PageTitle';
 
 const localMessages = {
   title: { id: 'about.title', defaultMessage: 'Page Not Found' },
   intro: { id: 'about.text', defaultMessage: 'That isn\'t a valid URL!' },
 };
 
-const PageNotFound = (props) => {
-  const title = props.intl.formatMessage(localMessages.title);
-  const titleHandler = parentTitle => `${title} | ${parentTitle}`;
-  return (
-    <Grid>
-      <Helmet><title>{titleHandler()}</title></Helmet>
-      <Row>
-        <Col lg={6} md={6} sm={6}>
-          <h1><FormattedMessage {...localMessages.title} /></h1>
-        </Col>
-      </Row>
-      <Row>
-        <Col lg={6} md={6} sm={6}>
-          <p><FormattedMessage {...localMessages.intro} /></p>
-        </Col>
-      </Row>
-    </Grid>
-  );
-};
-
+const PageNotFound = () => (
+  <Grid>
+    <PageTitle value={localMessages.title} />
+    <Row>
+      <Col lg={6} md={6} sm={6}>
+        <h1><FormattedMessage {...localMessages.title} /></h1>
+      </Col>
+    </Row>
+    <Row>
+      <Col lg={6} md={6} sm={6}>
+        <p><FormattedMessage {...localMessages.intro} /></p>
+      </Col>
+    </Row>
+  </Grid>
+);
 
 PageNotFound.propTypes = {
   // from context

--- a/src/components/common/PageTitle.js
+++ b/src/components/common/PageTitle.js
@@ -1,0 +1,70 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Helmet } from 'react-helmet';
+import { injectIntl } from 'react-intl';
+import messages from '../../resources/messages';
+import { intlIfObject } from '../../lib/stringUtil';
+import { getAppName } from '../../config';
+
+const nameForApp = () => {
+  const app = getAppName();
+  if (app === 'tools') {
+    return messages.toolsToolName;
+  }
+  if (app === 'explorer') {
+    return messages.explorerToolName;
+  }
+  if (app === 'topics') {
+    return messages.topicsToolName;
+  }
+  if (app === 'sources') {
+    return messages.sourcesToolName;
+  }
+  const error = `Unknown app name: ${app}`;
+  throw error;
+};
+
+const TITLE_SEPARATOR = ' | ';
+
+const PageTitle = (props) => {
+  const { formatMessage } = props.intl;
+  let passedInTitle = '';
+  if (props.value) {
+    if (props.value instanceof Array) {
+      passedInTitle = props.value.map(item => intlIfObject(formatMessage, item)).join(TITLE_SEPARATOR);
+    } else {
+      passedInTitle = intlIfObject(formatMessage, props.value);
+    }
+    passedInTitle += TITLE_SEPARATOR;
+  }
+  const titleString = `${passedInTitle}${formatMessage(nameForApp())}${TITLE_SEPARATOR}${formatMessage(messages.suiteName)}`;
+  return (
+    <Helmet>
+      <title>
+        {titleString}
+      </title>
+    </Helmet>
+  );
+};
+
+const intlMessageShape = {
+  id: PropTypes.string.isRequired,
+  defaultMessage: PropTypes.string.isRequired,
+};
+
+PageTitle.propTypes = {
+  // from parent
+  value: PropTypes.oneOfType([
+    PropTypes.string, // pass in a formatted string to use as the page title
+    PropTypes.arrayOf(PropTypes.string), // or an array of strings
+    PropTypes.shape(intlMessageShape), // or pass in a message to be formatted
+    PropTypes.arrayOf(PropTypes.shape(intlMessageShape)), // or an array of messages to be formatted
+  ]),
+  // from compositional chain
+  intl: PropTypes.object,
+};
+
+export default
+injectIntl(
+  PageTitle
+);

--- a/src/components/common/admin/story/StoryDetailsContainer.js
+++ b/src/components/common/admin/story/StoryDetailsContainer.js
@@ -11,18 +11,20 @@ import SelectedStoryContainer from './SelectedStoryContainer';
 import StorySearchForm from '../form/StorySearchForm';
 import { PERMISSION_ADMIN } from '../../../../lib/auth';
 import Permissioned from '../../Permissioned';
+import PageTitle from '../../PageTitle';
 
 const localMessages = {
-  storyTitle: { id: 'user.all.title', defaultMessage: 'Manage Stories' },
+  title: { id: 'user.all.title', defaultMessage: 'Manage Stories' },
 };
 
 const StoryDetailsContainer = props => (
   <Grid>
+    <PageTitle value={localMessages.title} />
     <Permissioned onlyRole={PERMISSION_ADMIN}>
       <Row>
         <Col lg={12}>
           <h1>
-            <FormattedMessage {...localMessages.storyTitle} />
+            <FormattedMessage {...localMessages.title} />
           </h1>
         </Col>
       </Row>

--- a/src/components/common/admin/users/ManageUsersContainer.js
+++ b/src/components/common/admin/users/ManageUsersContainer.js
@@ -5,6 +5,7 @@ import UserSearchForm from './UserSearchForm';
 import { PERMISSION_ADMIN } from '../../../../lib/auth';
 import Permissioned from '../../Permissioned';
 import UserListcontainer from './UserListContainer';
+import PageTitle from '../../PageTitle';
 
 const localMessages = {
   userTitle: { id: 'user.all.title', defaultMessage: 'Manage Users' },
@@ -19,6 +20,7 @@ class ManageUsersContainer extends React.Component {
   render() {
     return (
       <Grid>
+        <PageTitle value={localMessages.userTitle} />
         <Permissioned onlyRole={PERMISSION_ADMIN}>
           <Row>
             <h1>

--- a/src/components/common/admin/users/UpdateUserContainer.js
+++ b/src/components/common/admin/users/UpdateUserContainer.js
@@ -9,6 +9,7 @@ import { updateFeedback } from '../../../../actions/appActions';
 import UserForm from './UserForm';
 import { PERMISSION_ADMIN } from '../../../../lib/auth';
 import Permissioned from '../../Permissioned';
+import PageTitle from '../../PageTitle';
 
 const localMessages = {
   userTitle: { id: 'user.details.title', defaultMessage: '{name}: ' },
@@ -36,6 +37,7 @@ const UpdateUserContainer = (props) => {
   }
   return (
     <Grid className="details user-details">
+      <PageTitle value={localMessages.updateTitle} />
       <h1>
         <FormattedMessage {...localMessages.updateTitle} />
       </h1>

--- a/src/components/common/news/RecentNews.js
+++ b/src/components/common/news/RecentNews.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { Grid, Row, Col } from 'react-flexbox-grid/lib';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import ReleaseNotes from './ReleaseNotes';
+import PageTitle from '../PageTitle';
 
 const localMessages = {
   releaseNotes: { id: 'recentNews.releaseNotes', defaultMessage: 'Release Notes' },
@@ -11,6 +12,7 @@ const localMessages = {
 const RecentNews = props => (
   <div className="recent-news">
     <Grid>
+      <PageTitle value={localMessages.releaseNotes} />
       <Row>
         <Col lg={12}>
           <h1><FormattedMessage {...localMessages.releaseNotes} /></h1>

--- a/src/components/explorer/About.js
+++ b/src/components/explorer/About.js
@@ -1,50 +1,47 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Helmet } from 'react-helmet';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import { Grid, Row, Col } from 'react-flexbox-grid/lib';
 import ExplorerMarketingFeatureList from './home/ExplorerMarketingFeatureList';
 import messages from '../../resources/messages';
 import AppButton from '../common/AppButton';
 import { urlToExplorer } from '../../lib/urlUtil';
+import PageTitle from '../common/PageTitle';
 
 const localMessages = {
+  pageTitle: { id: 'about.pageTitle', defaultMessage: 'About' },
   aboutTitle: { id: 'about.title', defaultMessage: 'About Explorer' },
   aboutText: { id: 'about.text', defaultMessage: 'Explore our media tools!' },
 };
 
-const About = (props) => {
-  const title = props.intl.formatMessage(localMessages.aboutTitle);
-  return (
-    <div className="about">
-      <Grid>
-        <Helmet><title>{title}</title></Helmet>
+const About = () => (
+  <div className="about">
+    <Grid>
+      <PageTitle value={localMessages.pageTitle} />
+      <Row>
+        <Col lg={12}>
+          <h1><FormattedMessage {...localMessages.aboutTitle} /></h1>
+        </Col>
         <Row>
           <Col lg={12}>
-            <h1><FormattedMessage {...localMessages.aboutTitle} /></h1>
-          </Col>
-          <Row>
-            <Col lg={12}>
-              <p className="subtitle"><FormattedMessage {...messages.explorerToolDescription} /></p>
-            </Col>
-          </Row>
-        </Row>
-      </Grid>
-      <Grid>
-        <Row>
-          <Col lg={10} md={10} sm={10} />
-          <Col m={2} lg={2}>
-            <AppButton color="primary" primary onTouchTap={() => { window.location = urlToExplorer('queries/search?q=[{"label":"*","q":"*","color":"%231f77b4","sources":[],"collections":[58722749]}]'); }}>
-              <FormattedMessage {...messages.tryItNow} />
-            </AppButton>
+            <p className="subtitle"><FormattedMessage {...messages.explorerToolDescription} /></p>
           </Col>
         </Row>
-      </Grid>
-      <ExplorerMarketingFeatureList />
-    </div>
-  );
-};
-
+      </Row>
+    </Grid>
+    <Grid>
+      <Row>
+        <Col lg={10} md={10} sm={10} />
+        <Col m={2} lg={2}>
+          <AppButton color="primary" primary onTouchTap={() => { window.location = urlToExplorer('queries/search?q=[{"label":"*","q":"*","color":"%231f77b4","sources":[],"collections":[58722749]}]'); }}>
+            <FormattedMessage {...messages.tryItNow} />
+          </AppButton>
+        </Col>
+      </Row>
+    </Grid>
+    <ExplorerMarketingFeatureList />
+  </div>
+);
 
 About.propTypes = {
   // from context

--- a/src/components/explorer/ExplorerApp.js
+++ b/src/components/explorer/ExplorerApp.js
@@ -1,19 +1,15 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { injectIntl } from 'react-intl';
-import { Helmet } from 'react-helmet';
 import AppContainer from '../AppContainer';
 import messages from '../../resources/messages';
+import PageTitle from '../common/PageTitle';
 
 const ExplorerApp = (props) => {
   const { formatMessage } = props.intl;
   return (
     <div>
-      <Helmet>
-        <title>
-          {`${formatMessage(messages.explorerToolName)} | ${formatMessage(messages.suiteName)}`}
-        </title>
-      </Helmet>
+      <PageTitle />
       <AppContainer
         name="explorer"
         title={formatMessage(messages.explorerToolName)}

--- a/src/components/explorer/builder/DemoQueryContainer.js
+++ b/src/components/explorer/builder/DemoQueryContainer.js
@@ -9,9 +9,11 @@ import QueryBuilderContainer from './QueryBuilderContainer';
 import QueryResultsContainer from '../results/QueryResultsContainer';
 import { WarningNotice } from '../../common/Notice';
 import composeUrlBasedQueryContainer from '../UrlBasedQueryContainer';
+import PageTitle from '../../common/PageTitle';
 
 const localMessages = {
   register: { id: 'explorer.queryBuilder.urlParams', defaultMessage: 'Register for a free Media Cloud account to get access to all the Explorer features! <a href="http://tools.mediacloud.org/#/user/signup">Register Now</a>' },
+  title: { id: 'explorer.queryBuilder.sampleTitle', defaultMessage: 'Search Demo' },
 };
 
 class DemoQueryBuilderContainer extends React.Component {
@@ -33,6 +35,7 @@ class DemoQueryBuilderContainer extends React.Component {
     const isEditable = location.pathname.includes('queries/demo/search');
     return (
       <div className="query-container query-container-demo">
+        <PageTitle value={localMessages.title} />
         <div className="warning-background">
           <Grid>
             <Row>

--- a/src/components/explorer/builder/LoggedInQueryContainer.js
+++ b/src/components/explorer/builder/LoggedInQueryContainer.js
@@ -7,6 +7,11 @@ import { resetStory } from '../../../actions/storyActions';
 import QueryBuilderContainer from './QueryBuilderContainer';
 import QueryResultsContainer from '../results/QueryResultsContainer';
 import composeUrlBasedQueryContainer from '../UrlBasedQueryContainer';
+import PageTitle from '../../common/PageTitle';
+
+const localMessages = {
+  title: { id: 'explorer.queryBuilder.title', defaultMessage: 'Search' },
+};
 
 class LoggedInQueryContainer extends React.Component {
   componentWillMount() {
@@ -25,6 +30,7 @@ class LoggedInQueryContainer extends React.Component {
     const isEditable = false;
     return (
       <div className="query-container query-container-logged-in">
+        <PageTitle value={localMessages.title} />
         <QueryBuilderContainer isEditable={isEditable} onSearch={() => handleSearch()} />
         <QueryResultsContainer
           lastSearchTime={lastSearchTime}

--- a/src/components/source/About.js
+++ b/src/components/source/About.js
@@ -1,49 +1,47 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Helmet } from 'react-helmet';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import { Grid, Row, Col } from 'react-flexbox-grid/lib';
 import AppButton from '../common/AppButton';
 import SourcesMarketingFeatureList from './homepage/SourcesMarketingFeatureList';
 import messages from '../../resources/messages';
 import { urlToSourceManager } from '../../lib/urlUtil';
+import PageTitle from '../common/PageTitle';
 
 const localMessages = {
+  pageTitle: { id: 'about.pageTitle', defaultMessage: 'About' },
   aboutTitle: { id: 'about.title', defaultMessage: 'About Source Manager' },
   aboutText: { id: 'about.text', defaultMessage: 'Browse the media sources and collections in our database, and suggest more to add.' },
 };
 
-const About = (props) => {
-  const title = props.intl.formatMessage(localMessages.aboutTitle);
-  return (
-    <div className="about">
-      <Grid>
-        <Helmet><title>{title}</title></Helmet>
-        <Row>
-          <Col lg={12}>
-            <h1><FormattedMessage {...localMessages.aboutTitle} /></h1>
-          </Col>
-        </Row>
-        <Row>
-          <Col lg={12}>
-            <p className="subtitle"><FormattedMessage {...messages.sourcesToolDescription} /></p>
-          </Col>
-        </Row>
-      </Grid>
-      <Grid>
-        <Row>
-          <Col lg={10} md={10} sm={10} />
-          <Col m={2} lg={2}>
-            <AppButton color="primary" primary onTouchTap={() => { window.location = urlToSourceManager('home'); }}>
-              <FormattedMessage {...messages.tryItNow} />
-            </AppButton>
-          </Col>
-        </Row>
-      </Grid>
-      <SourcesMarketingFeatureList />
-    </div>
-  );
-};
+const About = () => (
+  <div className="about">
+    <Grid>
+      <PageTitle value={localMessages.pageTitle} />
+      <Row>
+        <Col lg={12}>
+          <h1><FormattedMessage {...localMessages.aboutTitle} /></h1>
+        </Col>
+      </Row>
+      <Row>
+        <Col lg={12}>
+          <p className="subtitle"><FormattedMessage {...messages.sourcesToolDescription} /></p>
+        </Col>
+      </Row>
+    </Grid>
+    <Grid>
+      <Row>
+        <Col lg={10} md={10} sm={10} />
+        <Col m={2} lg={2}>
+          <AppButton color="primary" primary onTouchTap={() => { window.location = urlToSourceManager('home'); }}>
+            <FormattedMessage {...messages.tryItNow} />
+          </AppButton>
+        </Col>
+      </Row>
+    </Grid>
+    <SourcesMarketingFeatureList />
+  </div>
+);
 
 
 About.propTypes = {

--- a/src/components/source/FavoritedContainer.js
+++ b/src/components/source/FavoritedContainer.js
@@ -7,8 +7,10 @@ import withAsyncFetch from '../common/hocs/AsyncContainer';
 import { fetchFavoriteSources, fetchFavoriteCollections } from '../../actions/systemActions';
 import SourceList from '../common/SourceList';
 import CollectionList from '../common/CollectionList';
+import PageTitle from '../common/PageTitle';
 
 const localMessages = {
+  starred: { id: 'sources.starred', defaultMessage: 'Starred' },
   title: { id: 'sources.menu.items.favoritedItems', defaultMessage: 'My Starred Sources And Collections' },
   favoritedCollectionsTitle: { id: 'favorited.collections.title', defaultMessage: 'My Starred Collections' },
   favoritedCollectionsIntro: { id: 'favorited.collections.intro', defaultMessage: 'These are collections you have starred by clicking the star next to their name.  This is useful to bookmark collections you use frequently.' },
@@ -21,6 +23,7 @@ const FavoritedContainer = (props) => {
   const { formatMessage } = props.intl;
   return (
     <Grid>
+      <PageTitle value={localMessages.starred} />
       <Row>
         <Col lg={12}>
           <h1><FormattedMessage {...localMessages.title} /></h1>

--- a/src/components/source/SourcesApp.js
+++ b/src/components/source/SourcesApp.js
@@ -1,19 +1,15 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { injectIntl } from 'react-intl';
-import { Helmet } from 'react-helmet';
 import AppContainer from '../AppContainer';
 import messages from '../../resources/messages';
+import PageTitle from '../common/PageTitle';
 
 const SourcesApp = (props) => {
   const { formatMessage } = props.intl;
   return (
     <div>
-      <Helmet>
-        <title>
-          {`${formatMessage(messages.sourcesToolName)} | ${formatMessage(messages.suiteName)}`}
-        </title>
-      </Helmet>
+      <PageTitle />
       <AppContainer
         name="sources"
         title={formatMessage(messages.sourcesToolName)}

--- a/src/components/source/collection/CollectionContentHistory.js
+++ b/src/components/source/collection/CollectionContentHistory.js
@@ -4,15 +4,15 @@ import { FormattedMessage, injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import { Grid, Row, Col } from 'react-flexbox-grid/lib';
 import { Link } from 'react-router';
-import { Helmet } from 'react-helmet';
 import { fetchCollectionSourceSplitStoryHistoricalCounts } from '../../../actions/sourceActions';
 import withAsyncFetch from '../../common/hocs/AsyncContainer';
 import { getBrandDarkColor } from '../../../styles/colors';
 import { DownloadButton } from '../../common/IconButton';
 import AttentionOverTimeChart from '../../vis/AttentionOverTimeChart';
+import PageTitle from '../../common/PageTitle';
 
 const localMessages = {
-  title: { id: 'collection.contentHistory.title', defaultMessage: 'Total Stories over Time' },
+  title: { id: 'collection.contentHistory.title', defaultMessage: 'Content History' },
   counts: { id: 'collection.contentHistory.counts', defaultMessage: '{total} Stories' },
 };
 
@@ -28,11 +28,10 @@ class CollectionContentHistory extends React.Component {
 
   render() {
     const { collection, historicalCounts } = this.props;
-    const { formatMessage, formatNumber } = this.props.intl;
-    const titleHandler = parentTitle => `${formatMessage(localMessages.title)} | ${parentTitle}`;
+    const { formatNumber } = this.props.intl;
     return (
       <div>
-        <Helmet><title>{titleHandler()}</title></Helmet>
+        <PageTitle value={[localMessages.title, collection.label]} />
         <Grid>
           <Row>
             <Col lg={10}>

--- a/src/components/source/collection/CreateCollectionContainer.js
+++ b/src/components/source/collection/CreateCollectionContainer.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Helmet } from 'react-helmet';
 import { push } from 'react-router-redux';
 import { injectIntl, FormattedMessage } from 'react-intl';
 import { connect } from 'react-redux';
@@ -13,6 +12,7 @@ import CollectionForm from './form/CollectionForm';
 import { PERMISSION_MEDIA_EDIT } from '../../../lib/auth';
 import Permissioned from '../../common/Permissioned';
 import { nullOrUndefined } from '../../../lib/formValidators';
+import PageTitle from '../../common/PageTitle';
 
 const localMessages = {
   mainTitle: { id: 'collection.maintitle', defaultMessage: 'Create New Collection' },
@@ -44,7 +44,6 @@ class CreateCollectionContainer extends React.Component {
   render() {
     const { handleSave, prefillSrcIds, prefillCollectionIds, sourcesToPrefill, collectionsToPrefill } = this.props;
     const { formatMessage } = this.props.intl;
-    const titleHandler = parentTitle => `${formatMessage(localMessages.mainTitle)} | ${parentTitle}`;
     const initialValues = {};
     let readyToShowForm = false;
     if ((prefillSrcIds || prefillCollectionIds)) {
@@ -73,7 +72,7 @@ class CreateCollectionContainer extends React.Component {
     return (
       <div className="create-collection">
         <Permissioned onlyRole={PERMISSION_MEDIA_EDIT}>
-          <Helmet><title>{titleHandler()}</title></Helmet>
+          <PageTitle value={localMessages.mainTitle} />
           <Grid>
             <Row>
               <Col lg={12}>

--- a/src/components/source/collection/EditCollectionContainer.js
+++ b/src/components/source/collection/EditCollectionContainer.js
@@ -12,6 +12,8 @@ import { PERMISSION_MEDIA_EDIT } from '../../../lib/auth';
 import Permissioned from '../../common/Permissioned';
 import { nullOrUndefined } from '../../../lib/formValidators';
 import FETCH_SUCCEEDED from '../../../lib/fetchConstants';
+import PageTitle from '../../common/PageTitle';
+import messages from '../../../resources/messages';
 
 const localMessages = {
   mainTitle: { id: 'collection.mainTitle', defaultMessage: 'Modify this Collection' },
@@ -33,6 +35,7 @@ const EditCollectionContainer = (props) => {
   };
   return (
     <div className="edit-collection">
+      <PageTitle value={[messages.edit, collection.label]} />
       <Permissioned onlyRole={PERMISSION_MEDIA_EDIT}>
         <Grid>
           <Row>

--- a/src/components/source/collection/ManageSourcesContainer.js
+++ b/src/components/source/collection/ManageSourcesContainer.js
@@ -19,6 +19,7 @@ import { SOURCE_SCRAPE_STATE_QUEUED, SOURCE_SCRAPE_STATE_RUNNING, SOURCE_SCRAPE_
 import FilledStarIcon from '../../common/icons/FilledStarIcon';
 import { googleFavIconUrl } from '../../../lib/urlUtil';
 import { parseSolrShortDate, jobStatusDateToMoment } from '../../../lib/dateUtil';
+import PageTitle from '../../common/PageTitle';
 
 const REVIEW = 0;
 const REMOVE = 1;
@@ -95,7 +96,7 @@ class ManageSourcesContainer extends React.Component {
   }
 
   render() {
-    const { collectionId, scrapeFeeds, sources, removeSource } = this.props;
+    const { collectionId, collection, scrapeFeeds, sources, removeSource } = this.props;
     const { formatMessage, formatDate } = this.props.intl;
     let viewSources = '';
     let viewDesc = '';
@@ -189,6 +190,7 @@ class ManageSourcesContainer extends React.Component {
     );
     return (
       <Grid>
+        <PageTitle value={[localMessages.title, collection.label]} />
         <Row>
           <Col lg={8}>
             <h1><FormattedMessage {...localMessages.title} /></h1>

--- a/src/components/source/collection/SelectCollectionContainer.js
+++ b/src/components/source/collection/SelectCollectionContainer.js
@@ -4,7 +4,6 @@ import { FormattedMessage, injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import Link from 'react-router/lib/Link';
 import { Grid } from 'react-flexbox-grid/lib';
-import { Helmet } from 'react-helmet';
 import { selectCollection, fetchCollectionDetails } from '../../../actions/sourceActions';
 import withAsyncFetch from '../../common/hocs/AsyncContainer';
 import SourceControlBar from '../controlbar/SourceControlBar';
@@ -14,7 +13,7 @@ import { EditButton, ExploreButton } from '../../common/IconButton';
 import SourceMgrHeaderContainer from '../SourceMgrHeaderContainer';
 import { getCurrentDate, oneMonthBefore } from '../../../lib/dateUtil';
 import { urlToExplorerQuery } from '../../../lib/urlUtil';
-import messages from '../../../resources/messages';
+import PageTitle from '../../common/PageTitle';
 
 const localMessages = {
   searchNow: { id: 'collection.details.searchNow', defaultMessage: 'Search in Explorer' },
@@ -47,10 +46,9 @@ class SelectCollectionContainer extends React.Component {
 
   render() {
     const { children, collection } = this.props;
-    const { formatMessage } = this.props.intl;
     return (
       <div className="collection-container">
-        <Helmet><title>{`${collection.label} | ${formatMessage(messages.sourcesToolName)} | ${formatMessage(messages.suiteName)}`}</title></Helmet>
+        <PageTitle value={collection.label} />
         <SourceMgrHeaderContainer />
         <SourceControlBar>
           <a href="search-in-explorer" onClick={this.searchInExplorer}>

--- a/src/components/source/collection/list/CountryCollectionListContainer.js
+++ b/src/components/source/collection/list/CountryCollectionListContainer.js
@@ -7,6 +7,7 @@ import withAsyncFetch from '../../../common/hocs/AsyncContainer';
 import CollectionIcon from '../../../common/icons/CollectionIcon';
 import { fetchGeoCollectionsByCountry } from '../../../../actions/sourceActions';
 import CollectionList from '../../../common/CollectionList';
+import PageTitle from '../../../common/PageTitle';
 
 const localMessages = {
   title: { id: 'sources.collections.geo.title', defaultMessage: 'Collections by Country' },
@@ -17,6 +18,7 @@ const CountryCollectionListContainer = (props) => {
   const { collectionsByCountry, user } = props;
   return (
     <div className="country-collections-table">
+      <PageTitle value={localMessages.title} />
       <Grid>
         <Row>
           <Col lg={10}>

--- a/src/components/source/collection/list/MCCollectionListContainer.js
+++ b/src/components/source/collection/list/MCCollectionListContainer.js
@@ -10,6 +10,7 @@ import TabSelector from '../../../common/TabSelector';
 import { TAG_SET_MC_ID, isCollectionTagSet } from '../../../../lib/tagUtil';
 import { PERMISSION_MEDIA_EDIT, getUserRoles, hasPermissions } from '../../../../lib/auth';
 import Permissioned from '../../../common/Permissioned';
+import PageTitle from '../../../common/PageTitle';
 
 const localMessages = {
   private: { id: 'sources.collections.mc.private', defaultMessage: 'Private' },
@@ -36,6 +37,7 @@ class MCCollectionListContainer extends React.Component {
     }
     return (
       <div className="mc-collections-table">
+        <PageTitle value={name} />
         <Grid>
           <h1>{name}</h1>
           <Permissioned onlyRole={PERMISSION_MEDIA_EDIT}>

--- a/src/components/source/mediaSource/CreateSourceContainer.js
+++ b/src/components/source/mediaSource/CreateSourceContainer.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Helmet } from 'react-helmet';
 import { push } from 'react-router-redux';
 import { injectIntl, FormattedMessage } from 'react-intl';
 import { connect } from 'react-redux';
@@ -12,6 +11,7 @@ import SourceForm from './form/SourceForm';
 import { PERMISSION_MEDIA_EDIT } from '../../../lib/auth';
 import Permissioned from '../../common/Permissioned';
 import { nullOrUndefined } from '../../../lib/formValidators';
+import PageTitle from '../../common/PageTitle';
 
 const localMessages = {
   mainTitle: { id: 'source.maintitle', defaultMessage: 'Create New Source' },
@@ -24,11 +24,10 @@ const localMessages = {
 const CreateSourceContainer = (props) => {
   const { handleSave } = props;
   const { formatMessage } = props.intl;
-  const titleHandler = parentTitle => `${formatMessage(localMessages.mainTitle)} | ${parentTitle}`;
   return (
     <div className="create-source">
       <Permissioned onlyRole={PERMISSION_MEDIA_EDIT}>
-        <Helmet><title>{titleHandler()}</title></Helmet>
+        <PageTitle value={localMessages.mainTitle} />
         <Grid>
           <Row>
             <Col lg={12}>

--- a/src/components/source/mediaSource/EditSourceContainer.js
+++ b/src/components/source/mediaSource/EditSourceContainer.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Helmet } from 'react-helmet';
 import { push } from 'react-router-redux';
 import { injectIntl, FormattedMessage } from 'react-intl';
 import { connect } from 'react-redux';
@@ -13,6 +12,7 @@ import { getUserRoles, hasPermissions, PERMISSION_MEDIA_EDIT } from '../../../li
 import Permissioned from '../../common/Permissioned';
 import { nullOrUndefined } from '../../../lib/formValidators';
 import messages from '../../../resources/messages';
+import PageTitle from '../../common/PageTitle';
 
 const localMessages = {
   mainTitle: { id: 'source.maintitle', defaultMessage: 'Modify this Source' },
@@ -38,7 +38,7 @@ const EditSourceContainer = (props) => {
   };
   return (
     <div className="edit-source">
-      <Helmet><title>{`${formatMessage(messages.edit)} ${source.name} | ${formatMessage(messages.sourcesToolName)} | ${formatMessage(messages.suiteName)}`}</title></Helmet>
+      <PageTitle value={[messages.edit, source.name]} />
       <Permissioned onlyRole={PERMISSION_MEDIA_EDIT}>
         <Grid>
           <Row>

--- a/src/components/source/mediaSource/EditSourceFeedContainer.js
+++ b/src/components/source/mediaSource/EditSourceFeedContainer.js
@@ -15,6 +15,7 @@ import SourceFeedForm from './form/SourceFeedForm';
 import { PERMISSION_MEDIA_EDIT } from '../../../lib/auth';
 import Permissioned from '../../common/Permissioned';
 import FeedRecentStoriesContainer from './FeedRecentStoriesContainer';
+import PageTitle from '../../common/PageTitle';
 
 const localMessages = {
   sourceFeedsTitle: { id: 'source.details.feeds.title', defaultMessage: '{name}: ' },
@@ -56,6 +57,7 @@ class EditSourceFeedContainer extends React.Component {
     }
     return (
       <Grid className="details source-feed-details">
+        <PageTitle value={[localMessages.updateFeedsTitle, sourceName]} />
         <h2>
           <MediaSourceIcon height={32} />
           <Link to={`/sources/${sourceId}/feeds`}>

--- a/src/components/source/mediaSource/SelectSourceContainer.js
+++ b/src/components/source/mediaSource/SelectSourceContainer.js
@@ -4,7 +4,6 @@ import { FormattedMessage, injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import { Grid } from 'react-flexbox-grid/lib';
 import Link from 'react-router/lib/Link';
-import { Helmet } from 'react-helmet';
 import { getCurrentDate, oneMonthBefore } from '../../../lib/dateUtil';
 import { urlToExplorerQuery } from '../../../lib/urlUtil';
 import { selectSource, fetchSourceDetails } from '../../../actions/sourceActions';
@@ -14,7 +13,7 @@ import Permissioned from '../../common/Permissioned';
 import { PERMISSION_MEDIA_EDIT } from '../../../lib/auth';
 import { EditButton, ExploreButton } from '../../common/IconButton';
 import SourceMgrHeaderContainer from '../SourceMgrHeaderContainer';
-import messages from '../../../resources/messages';
+import PageTitle from '../../common/PageTitle';
 
 const localMessages = {
   title: { id: 'source.title', defaultMessage: '{name} | Source Summary | Media Cloud' },
@@ -48,10 +47,9 @@ class SelectSourceContainer extends React.Component {
 
   render() {
     const { children, source } = this.props;
-    const { formatMessage } = this.props.intl;
     return (
       <div className="source-container">
-        <Helmet><title>{`${source.name} | ${formatMessage(messages.sourcesToolName)} | ${formatMessage(messages.suiteName)}`}</title></Helmet>
+        <PageTitle value={source.name} />
         <SourceMgrHeaderContainer />
         <SourceControlBar>
           <a href="search-in-explorer" onClick={this.searchInExplorer}>

--- a/src/components/source/mediaSource/SourceFeedContainer.js
+++ b/src/components/source/mediaSource/SourceFeedContainer.js
@@ -5,7 +5,6 @@ import { connect } from 'react-redux';
 import { Grid, Row, Col } from 'react-flexbox-grid/lib';
 import Link from 'react-router/lib/Link';
 import { push } from 'react-router-redux';
-import { Helmet } from 'react-helmet';
 import { fetchSourceFeeds, scrapeSourceFeeds, fetchSourceDetails } from '../../../actions/sourceActions';
 import withAsyncFetch from '../../common/hocs/AsyncContainer';
 import MediaSourceIcon from '../../common/icons/MediaSourceIcon';
@@ -17,8 +16,10 @@ import Permissioned from '../../common/Permissioned';
 import { PERMISSION_MEDIA_EDIT } from '../../../lib/auth';
 import { updateFeedback } from '../../../actions/appActions';
 import { SOURCE_SCRAPE_STATE_QUEUED, SOURCE_SCRAPE_STATE_RUNNING } from '../../../reducers/sources/sources/selected/sourceDetails';
+import PageTitle from '../../common/PageTitle';
 
 const localMessages = {
+  pageTitle: { id: 'source.feeds.pageTitle', defaultMessage: 'Feeds' },
   title: { id: 'source.feeds.title', defaultMessage: '{name} | Source Feeds | Media Cloud' },
   sourceFeedsTitle: { id: 'source.details.feeds.title', defaultMessage: '{name}: Feeds' },
   add: { id: 'source.deatils.feeds.add', defaultMessage: 'Add A Feed' },
@@ -51,7 +52,7 @@ class SourceFeedContainer extends React.Component {
     }
     return (
       <Grid className="details source-details">
-        <Helmet><title>{formatMessage(localMessages.title, { name: sourceName })}</title></Helmet>
+        <PageTitle value={[localMessages.pageTitle, sourceName]} />
         <Row>
           <Col lg={11} xs={11}>
             <h1>

--- a/src/components/source/mediaSource/suggest/AllSuggestionsContainer.js
+++ b/src/components/source/mediaSource/suggest/AllSuggestionsContainer.js
@@ -1,41 +1,36 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Helmet } from 'react-helmet';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import { Grid, Row, Col } from 'react-flexbox-grid/lib';
 import { fetchSourceSuggestions } from '../../../../actions/sourceActions';
 import withAsyncFetch from '../../../common/hocs/AsyncContainer';
 import SourceSuggestion from './SourceSuggestion';
+import PageTitle from '../../../common/PageTitle';
 
 const localMessages = {
   title: { id: 'sources.suggestions.pending.title', defaultMessage: 'All Suggestions' },
 };
 
-const allSuggestionsContainer = (props) => {
-  const { suggestions } = props;
-  const { formatMessage } = props.intl;
-  const titleHandler = parentTitle => `${formatMessage(localMessages.title)} | ${parentTitle}`;
-  return (
-    <Grid>
-      <Row>
-        <Col lg={12} md={12} sm={12}>
-          <Helmet><title>{titleHandler()}</title></Helmet>
-          <h1><FormattedMessage {...localMessages.title} /></h1>
+const AllSuggestionsContainer = props => (
+  <Grid>
+    <PageTitle value={localMessages.title} />
+    <Row>
+      <Col lg={12} md={12} sm={12}>
+        <h1><FormattedMessage {...localMessages.title} /></h1>
+      </Col>
+    </Row>
+    <Row>
+      { props.suggestions.map(s => (
+        <Col key={s.media_suggestions_id} lg={4}>
+          <SourceSuggestion suggestion={s} markable={false} />
         </Col>
-      </Row>
-      <Row>
-        { suggestions.map(s => (
-          <Col key={s.media_suggestions_id} lg={4}>
-            <SourceSuggestion suggestion={s} markable={false} />
-          </Col>
-        ))}
-      </Row>
-    </Grid>
-  );
-};
+      ))}
+    </Row>
+  </Grid>
+);
 
-allSuggestionsContainer.propTypes = {
+AllSuggestionsContainer.propTypes = {
   // from the composition chain
   intl: PropTypes.object.isRequired,
   // from parent
@@ -59,7 +54,7 @@ export default
 injectIntl(
   connect(mapStateToProps, mapDispatchToProps)(
     withAsyncFetch(
-      allSuggestionsContainer
+      AllSuggestionsContainer
     )
   )
 );

--- a/src/components/source/mediaSource/suggest/PendingSuggestionsContainer.js
+++ b/src/components/source/mediaSource/suggest/PendingSuggestionsContainer.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Helmet } from 'react-helmet';
 import Link from 'react-router/lib/Link';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
@@ -8,6 +7,7 @@ import { Grid, Row, Col } from 'react-flexbox-grid/lib';
 import { fetchSourceSuggestions, updateSourceSuggestion } from '../../../../actions/sourceActions';
 import withAsyncFetch from '../../../common/hocs/AsyncContainer';
 import SourceSuggestion from './SourceSuggestion';
+import PageTitle from '../../../common/PageTitle';
 
 const localMessages = {
   title: { id: 'sources.suggestions.pending.title', defaultMessage: 'Pending Suggestions' },
@@ -17,13 +17,11 @@ const localMessages = {
 
 const PendingSuggestionsContainer = (props) => {
   const { suggestions, handleApprove, handleReject } = props;
-  const { formatMessage } = props.intl;
-  const titleHandler = parentTitle => `${formatMessage(localMessages.title)} | ${parentTitle}`;
   return (
     <Grid>
       <Row>
         <Col lg={12} md={12} sm={12}>
-          <Helmet><title>{titleHandler()}</title></Helmet>
+          <PageTitle value={localMessages.title} />
           <h1><FormattedMessage {...localMessages.title} /></h1>
           <p><FormattedMessage {...localMessages.intro} /></p>
           <p>

--- a/src/components/source/mediaSource/suggest/SuggestSourceContainer.js
+++ b/src/components/source/mediaSource/suggest/SuggestSourceContainer.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Helmet } from 'react-helmet';
 import { reduxForm, reset } from 'redux-form';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
@@ -12,6 +11,7 @@ import { emptyString } from '../../../../lib/formValidators';
 import { suggestSource } from '../../../../actions/sourceActions';
 import { updateFeedback } from '../../../../actions/appActions';
 import AppButton from '../../../common/AppButton';
+import PageTitle from '../../../common/PageTitle';
 
 const localMessages = {
   mainTitle: { id: 'source.suggest.maintitle', defaultMessage: 'Suggest A Source' },
@@ -25,10 +25,9 @@ const localMessages = {
 const SuggestSourceContainer = (props) => {
   const { initialValues, pristine, submitting, handleSubmit, handleSave } = props;
   const { formatMessage } = props.intl;
-  const titleHandler = formatMessage(localMessages.mainTitle);
   return (
     <div>
-      <Helmet><title>{titleHandler}</title></Helmet>
+      <PageTitle value={localMessages.mainTitle} />
       <Grid>
         <Row>
           <Col lg={12}>

--- a/src/components/source/search/AdvancedSearchContainer.js
+++ b/src/components/source/search/AdvancedSearchContainer.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Helmet } from 'react-helmet';
 // import { formValueSelector } from 'redux-form';
 import { injectIntl, FormattedMessage } from 'react-intl';
 import { connect } from 'react-redux';
@@ -8,6 +7,8 @@ import { Grid, Row, Col } from 'react-flexbox-grid/lib';
 import Divider from '@material-ui/core/Divider';
 import AdvancedSearchForm from './AdvancedSearchForm';
 import AdvancedSearchResultsContainer from './AdvancedSearchResultsContainer';
+import PageTitle from '../../common/PageTitle';
+import messages from '../../../resources/messages';
 
 // const formSelector = formValueSelector('advancedQueryForm');
 
@@ -32,14 +33,13 @@ class AdvancedSearchContainer extends React.Component {
 
   render() {
     const { formatMessage } = this.props.intl;
-    const titleHandler = parentTitle => `${formatMessage(localMessages.mainTitle)} | ${parentTitle}`;
     let resultsContent = null;
     if ((this.state.queryStr) || (this.state.tags.length > 0)) {
       resultsContent = <AdvancedSearchResultsContainer searchString={this.state.queryStr} tags={this.state.tags} />;
     }
     return (
       <div>
-        <Helmet><title>{titleHandler()}</title></Helmet>
+        <PageTitle value={messages.search} />
         <Grid>
           <Row>
             <Col lg={12}>

--- a/src/components/tools/ToolsHomeContainer.js
+++ b/src/components/tools/ToolsHomeContainer.js
@@ -3,7 +3,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { Grid, Row, Col } from 'react-flexbox-grid/lib';
 import { FormattedMessage, injectIntl } from 'react-intl';
-import { Helmet } from 'react-helmet';
 import messages from '../../resources/messages';
 import { TOPICS_URL, EXPLORER_URL, SOURCES_URL } from '../common/header/NavToolbar';
 import ToolDescription from './ToolDescription';
@@ -12,6 +11,7 @@ import SystemStatsContainer from '../common/statbar/SystemStatsContainer';
 import LoginForm from '../user/LoginForm';
 import DataCard from '../common/DataCard';
 import { assetUrl } from '../../lib/assetUtil';
+import PageTitle from '../common/PageTitle';
 
 const localMessages = {
   title: { id: 'tools.home.title', defaultMessage: 'Welcome to Media Cloud' },
@@ -21,7 +21,6 @@ const localMessages = {
 
 const ToolsHomeContainer = (props) => {
   const { isLoggedIn } = props;
-  const { formatMessage } = props.intl;
   const notLoggedInContent = (
     <Row>
       <Col lg={8}>
@@ -45,7 +44,7 @@ const ToolsHomeContainer = (props) => {
   const content = (isLoggedIn) ? loggedInContent : notLoggedInContent;
   return (
     <div className="tools-home about-page">
-      <Helmet><title>{`${formatMessage(messages.toolsToolName)} | ${formatMessage(messages.suiteName)}`}</title></Helmet>
+      <PageTitle />
       <Grid>
         <Row>
           <Col lg={12}>

--- a/src/components/topic/About.js
+++ b/src/components/topic/About.js
@@ -1,50 +1,47 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Helmet } from 'react-helmet';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import { Grid, Row, Col } from 'react-flexbox-grid/lib';
 import AppButton from '../common/AppButton';
 import TopicsMarketingFeatureList from './homepage/TopicsMarketingFeatureList';
 import messages from '../../resources/messages';
 import { urlToTopicMapper } from '../../lib/urlUtil';
+import PageTitle from '../common/PageTitle';
 
 const localMessages = {
+  pageTitle: { id: 'about.title', defaultMessage: 'About' },
   aboutTitle: { id: 'about.title', defaultMessage: 'About Topic Mapper' },
   aboutText: { id: 'about.text', defaultMessage: 'Topic Mapper lets you analyze how online media talks about a topic.' },
 };
 
-const About = (props) => {
-  const title = props.intl.formatMessage(localMessages.aboutTitle);
-  return (
-    <div className="about">
-      <Grid>
-        <Helmet><title>{title}</title></Helmet>
-        <Row>
-          <Col lg={6} md={6} sm={6}>
-            <h1><FormattedMessage {...localMessages.aboutTitle} /></h1>
-          </Col>
-        </Row>
-        <Row>
-          <Col lg={12}>
-            <p className="subtitle"><FormattedMessage {...messages.topicsToolDescription} /></p>
-          </Col>
-        </Row>
-      </Grid>
-      <Grid>
-        <Row>
-          <Col lg={10} md={10} sm={10} />
-          <Col m={2} lg={2}>
-            <AppButton color="primary" primary onTouchTap={() => { window.location = urlToTopicMapper('home'); }}>
-              <FormattedMessage {...messages.tryItNow} />
-            </AppButton>
-          </Col>
-        </Row>
-      </Grid>
-      <TopicsMarketingFeatureList />
-    </div>
-  );
-};
-
+const About = () => (
+  <div className="about">
+    <Grid>
+      <PageTitle value={localMessages.pageTitle} />
+      <Row>
+        <Col lg={6} md={6} sm={6}>
+          <h1><FormattedMessage {...localMessages.aboutTitle} /></h1>
+        </Col>
+      </Row>
+      <Row>
+        <Col lg={12}>
+          <p className="subtitle"><FormattedMessage {...messages.topicsToolDescription} /></p>
+        </Col>
+      </Row>
+    </Grid>
+    <Grid>
+      <Row>
+        <Col lg={10} md={10} sm={10} />
+        <Col m={2} lg={2}>
+          <AppButton color="primary" primary onTouchTap={() => { window.location = urlToTopicMapper('home'); }}>
+            <FormattedMessage {...messages.tryItNow} />
+          </AppButton>
+        </Col>
+      </Row>
+    </Grid>
+    <TopicsMarketingFeatureList />
+  </div>
+);
 
 About.propTypes = {
   // from context

--- a/src/components/topic/TopicContainer.js
+++ b/src/components/topic/TopicContainer.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Helmet } from 'react-helmet';
 import { push, replace } from 'react-router-redux';
 import { Grid, Row, Col } from 'react-flexbox-grid/lib';
 import { injectIntl, FormattedMessage } from 'react-intl';
@@ -20,7 +19,7 @@ import TopicHeaderContainer from './TopicHeaderContainer';
 import Permissioned from '../common/Permissioned';
 import { PERMISSION_TOPIC_WRITE, PERMISSION_ADMIN } from '../../lib/auth';
 import { ADMIN_MAX_RECOMMENDED_STORIES, MAX_RECOMMENDED_STORIES } from '../../lib/formValidators';
-import messages from '../../resources/messages';
+import PageTitle from '../common/PageTitle';
 
 const localMessages = {
   needsSnapshotWarning: { id: 'needSnapshot.warning', defaultMessage: 'You\'ve made changes to your Topic that require a new snapshot to be generated!' },
@@ -186,11 +185,9 @@ class TopicContainer extends React.Component {
     }
     return (
       <div className="topic-container">
-        <div>
-          <Helmet><title>{`${topicInfo.name} | ${formatMessage(messages.topicsToolName)} | ${formatMessage(messages.suiteName)}`}</title></Helmet>
-          <TopicHeaderContainer topicId={topicId} topicInfo={topicInfo} filters={filters} />
-          {contentToShow}
-        </div>
+        <PageTitle value={topicInfo.name} />
+        <TopicHeaderContainer topicId={topicId} topicInfo={topicInfo} filters={filters} />
+        {contentToShow}
       </div>
     );
   }

--- a/src/components/topic/TopicPageTitle.js
+++ b/src/components/topic/TopicPageTitle.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import PageTitle from '../common/PageTitle';
+
+const TopicPageTitle = (props) => {
+  let newValue;
+  if (props.value instanceof Array) {
+    newValue = [...props.value, props.topicName];
+  } else {
+    newValue = [props.value, props.topicName];
+  }
+  return (<PageTitle value={newValue} />);
+};
+
+TopicPageTitle.propTypes = {
+  // from parent
+  value: PropTypes.object,
+  // from state
+  topicName: PropTypes.string.isRequired,
+};
+
+const mapStateToProps = state => ({
+  topicName: state.topics.selected.info.name,
+});
+
+export default
+connect(mapStateToProps)(
+  TopicPageTitle
+);

--- a/src/components/topic/TopicsApp.js
+++ b/src/components/topic/TopicsApp.js
@@ -1,15 +1,15 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { injectIntl } from 'react-intl';
-import { Helmet } from 'react-helmet';
 import AppContainer from '../AppContainer';
 import messages from '../../resources/messages';
+import PageTitle from '../common/PageTitle';
 
 const TopicsApp = (props) => {
   const { formatMessage } = props.intl;
   return (
     <div>
-      <Helmet><title>{`${formatMessage(messages.topicsToolName)} | ${formatMessage(messages.suiteName)}`}</title></Helmet>
+      <PageTitle />
       <AppContainer
         name="topics"
         title={formatMessage(messages.topicsToolName)}

--- a/src/components/topic/attention/AttentionContainer.js
+++ b/src/components/topic/attention/AttentionContainer.js
@@ -1,12 +1,12 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Helmet } from 'react-helmet';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import { Grid, Row, Col } from 'react-flexbox-grid/lib';
 import FocusSetSelectorContainer, { NO_FOCAL_SET_SELECTED } from './FocusSetSelectorContainer';
 import FociAttentionComparisonContainer from './FociAttentionComparisonContainer';
 import { setAttentionFocalSetId } from '../../../actions/topicActions';
+import PageTitle from '../../common/PageTitle';
 
 const localMessages = {
   mainTitle: { id: 'attention.mainTitle', defaultMessage: 'Attention Scoreboard' },
@@ -15,7 +15,6 @@ const localMessages = {
 
 const AttentionContainer = (props) => {
   const { selectedFocalSetId, filters, focalSets, topicId, handleFocalSetSelected } = props;
-  const { formatMessage } = props.intl;
   let content = null;
   const defaultFocalSet = focalSets.length > 0 ? focalSets[0].focal_sets_id : NO_FOCAL_SET_SELECTED;
   if (selectedFocalSetId !== NO_FOCAL_SET_SELECTED) {
@@ -39,7 +38,7 @@ const AttentionContainer = (props) => {
   }
   return (
     <div>
-      <Helmet><title>{formatMessage(localMessages.mainTitle)}</title></Helmet>
+      <PageTitle value={localMessages.mainTitle} />
       <Grid>
         <Row>
           <Col lg={12}>

--- a/src/components/topic/create/CreateTopicContainer.js
+++ b/src/components/topic/create/CreateTopicContainer.js
@@ -7,24 +7,29 @@ import { fetchUserQueuedAndRunningTopics } from '../../../actions/topicActions';
 import { WarningNotice } from '../../common/Notice';
 import TopicBuilderWizard from './TopicBuilderWizard';
 import { getUserRoles, hasPermissions, PERMISSION_TOPIC_ADMIN } from '../../../lib/auth';
+import PageTitle from '../../common/PageTitle';
 
 const localMessages = {
+  pageTitle: { id: 'topic.create.pageTitle', defaultMessage: 'Create a Topic' },
   cannotCreateTopic: { id: 'topic.create.cannotCreateTopic', defaultMessage: 'You cannot create a new topic right now because you are currently running another topic: {name} #{id}' },
 };
 
 const CreateTopicContainer = (props) => {
   const { canCreateTopic, runningTopics, user } = props;
-
+  // users can only have one running topic at once
   if (!hasPermissions(getUserRoles(user), PERMISSION_TOPIC_ADMIN) && !canCreateTopic) {
     return (
       <WarningNotice><FormattedHTMLMessage {...localMessages.cannotCreateTopic} values={{ name: runningTopics[0].name, id: runningTopics[0].topics_id }} /></WarningNotice>
     );
   }
   return (
-    <TopicBuilderWizard
-      startStep={0}
-      location={window.location}
-    />
+    <React.Fragment>
+      <PageTitle value={localMessages.pageTitle} />
+      <TopicBuilderWizard
+        startStep={0}
+        location={window.location}
+      />
+    </React.Fragment>
   );
 };
 

--- a/src/components/topic/create/EditTopicContainer.js
+++ b/src/components/topic/create/EditTopicContainer.js
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { push } from 'react-router-redux';
-import { Helmet } from 'react-helmet';
 import { connect } from 'react-redux';
 import { FormattedMessage } from 'react-intl';
 import { reduxForm } from 'redux-form';
@@ -22,9 +21,10 @@ import { PERMISSION_TOPIC_WRITE } from '../../../lib/auth';
 import TopicForm from './TopicForm';
 import { TOPIC_FORM_MODE_EDIT } from './TopicDetailForm';
 import UpdateForStorySearchWarning from '../UpdateForStorySearchWarning';
+import TopicPageTitle from '../TopicPageTitle';
 
 const localMessages = {
-  editTopicTitle: { id: 'topic.edit.title', defaultMessage: 'Edit Topic Settings' },
+  editTopicTitle: { id: 'topic.edit.title', defaultMessage: 'Topic Settings' },
   editTopicText: { id: 'topic.edit.text', defaultMessage: 'You can update this Topic. If you make changes to the query, media sourcs, or dates, those will be reflected in the next snapshot you run.' },
   editTopic: { id: 'topic.edit', defaultMessage: 'Edit Topic' },
   editTopicCollectionsTitle: { id: 'topic.edit.editTopicCollectionsTitle', defaultMessage: 'Edit Sources and Collections' },
@@ -143,7 +143,7 @@ class EditTopicContainer extends React.Component {
       <div className="topic-edit-form">
         <BackLinkingControlBar message={messages.backToTopic} linkTo={`/topics/${topicId}/summary`} />
         <Grid>
-          <Helmet><title>{formatMessage(localMessages.editTopicTitle)}</title></Helmet>
+          <TopicPageTitle value={localMessages.editTopicTitle} />
           <Row>
             <Col lg={12}>
               <h1><FormattedMessage {...localMessages.editTopicTitle} /></h1>

--- a/src/components/topic/create/TopicCreate1ConfigureContainer.js
+++ b/src/components/topic/create/TopicCreate1ConfigureContainer.js
@@ -5,7 +5,6 @@ import { push } from 'react-router-redux';
 import { reduxForm, formValueSelector } from 'redux-form';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import { Grid, Row, Col } from 'react-flexbox-grid/lib';
-import { Helmet } from 'react-helmet';
 import withAsyncFetch from '../../common/hocs/AsyncContainer';
 import withIntlForm from '../../common/hocs/IntlForm';
 import TopicForm, { TOPIC_FORM_MODE_CREATE } from './TopicForm';
@@ -36,7 +35,6 @@ const TopicCreate1ConfigureContainer = (props) => {
   const initialValues = { start_date: startDate, end_date: endDate, max_iterations: 15, max_topic_stories: maxStories, buttonLabel: formatMessage(messages.preview), sourcesAndCollections: sAndC };
   return (
     <Grid>
-      <Helmet><title>{formatMessage(localMessages.title)}</title></Helmet>
       <Row>
         <Col lg={10}>
           <h1><FormattedMessage {...localMessages.title} /></h1>

--- a/src/components/topic/homepage/TopicsHomepage.js
+++ b/src/components/topic/homepage/TopicsHomepage.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Helmet } from 'react-helmet';
 import { connect } from 'react-redux';
 import Link from 'react-router/lib/Link';
 import { FormattedMessage, injectIntl, FormattedHTMLMessage } from 'react-intl';
@@ -26,23 +25,10 @@ const localMessages = {
 
 const TopicsHomepage = (props) => {
   const { user } = props;
-  const { formatMessage } = props.intl;
-  const title = formatMessage(localMessages.homeTitle);
-  const titleHandler = parentTitle => `${title} | ${parentTitle}`;
   let content = null;
-  const mastHead = (
-    <Masthead
-      nameMsg={messages.topicsToolName}
-      descriptionMsg={messages.topicsToolDescription}
-      link="https://mediacloud.org/tools/"
-    />
-  );
   if (user.isLoggedIn) {
     content = (
       <div>
-
-        <Helmet><title>{`${formatMessage(localMessages.homeTitle)} | ${formatMessage(messages.topicsToolName)} | ${formatMessage(messages.suiteName)}`}</title></Helmet>
-
         <div className="controlbar">
           <div className="main">
             <Grid>
@@ -72,9 +58,6 @@ const TopicsHomepage = (props) => {
   } else {
     content = (
       <div>
-
-        <Helmet><title>{titleHandler()}</title></Helmet>
-
         <Grid>
           <Row>
             <Col lg={1} xs={0} />
@@ -108,7 +91,11 @@ const TopicsHomepage = (props) => {
   }
   return (
     <div className="homepage">
-      {mastHead}
+      <Masthead
+        nameMsg={messages.topicsToolName}
+        descriptionMsg={messages.topicsToolDescription}
+        link="https://mediacloud.org/tools/"
+      />
       {content}
     </div>
   );

--- a/src/components/topic/list/TopicStatusDashboardContainer.js
+++ b/src/components/topic/list/TopicStatusDashboardContainer.js
@@ -9,6 +9,7 @@ import { Grid, Row, Col } from 'react-flexbox-grid/lib';
 import withAsyncFetch from '../../common/hocs/AsyncContainer';
 import { fetchAdminTopicList } from '../../../actions/topicActions';
 import TopicStatusTable from './TopicStatusTable';
+import PageTitle from '../../common/PageTitle';
 
 const localMessages = {
   title: { id: 'topics.adminList.title', defaultMessage: 'Admin: Topic Status Dashboard' },
@@ -29,6 +30,7 @@ class TopicStatusDashboardContainer extends React.Component {
     const topicsToShow = topics.filter(t => t.state === this.state.selectedTopicState);
     return (
       <Grid>
+        <PageTitle value={localMessages.title} />
         <Row>
           <Col lg={12}>
             <h1><FormattedMessage {...localMessages.title} /></h1>

--- a/src/components/topic/maps/LinkMapContainer.js
+++ b/src/components/topic/maps/LinkMapContainer.js
@@ -1,12 +1,12 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Helmet } from 'react-helmet';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import { Grid, Row, Col } from 'react-flexbox-grid/lib';
 import LinkMapForm from './LinkMapForm';
 import { selectTopic, filterBySnapshot, filterByFocus, filterByTimespan } from '../../../actions/topicActions';
 import { generateParamStr } from '../../../lib/apiUtil';
+import TopicPageTitle from '../TopicPageTitle';
 
 const localMessages = {
   title: { id: 'topic.maps.link.title', defaultMessage: 'Link Map' },
@@ -38,12 +38,10 @@ class LinkMapContainer extends React.Component {
   render() {
     const { handleFetchMapData, filters, topicId } = this.props;
     const { formatMessage } = this.props.intl;
-    const titleHandler = parentTitle => `${formatMessage(localMessages.title)} | ${parentTitle}`;
     const initialValues = { color_field: 'media_type', num_media: 500, include_weights: false };
-
     return (
       <Grid>
-        <Helmet><title>{titleHandler()}</title></Helmet>
+        <TopicPageTitle value={localMessages.title} />
         <Row>
           <Col lg={12} md={12} sm={12}>
             <h1><FormattedMessage {...localMessages.title} /></h1>

--- a/src/components/topic/media/InfluentialMediaContainer.js
+++ b/src/components/topic/media/InfluentialMediaContainer.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Helmet } from 'react-helmet';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import { push } from 'react-router-redux';
@@ -15,6 +14,7 @@ import withAsyncFetch from '../../common/hocs/AsyncContainer';
 import { pagedAndSortedLocation } from '../../util/location';
 import withPaging from '../../common/hocs/PagedContainer';
 import MediaSourceIcon from '../../common/icons/MediaSourceIcon';
+import TopicPageTitle from '../TopicPageTitle';
 
 const localMessages = {
   title: { id: 'topic.influentialMedia.title', defaultMessage: 'Influential Media' },
@@ -44,12 +44,11 @@ class InfluentialMediaContainer extends React.Component {
   render() {
     const { media, sort, topicId, previousButton, nextButton } = this.props;
     const { formatMessage } = this.props.intl;
-    const titleHandler = parentTitle => `${formatMessage(localMessages.title)} | ${parentTitle}`;
     return (
       <Grid>
         <Row>
           <Col lg={12} md={12} sm={12}>
-            <Helmet><title>{titleHandler()}</title></Helmet>
+            <TopicPageTitle value={localMessages.title} />
             <TopicSourceSearchContainer topicId={topicId} showSearch />
             <DataCard border={false}>
               <div className="actions">

--- a/src/components/topic/media/MediaContainer.js
+++ b/src/components/topic/media/MediaContainer.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Helmet } from 'react-helmet';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import Dialog from '@material-ui/core/Dialog';
 import DialogTitle from '@material-ui/core/DialogTitle';
@@ -25,6 +24,7 @@ import { PERMISSION_TOPIC_WRITE } from '../../../lib/auth';
 import StatBar from '../../common/statbar/StatBar';
 import CollectionList from '../../common/CollectionList';
 import SourceMetadataStatBar from '../../common/SourceMetadataStatBar';
+import TopicPageTitle from '../TopicPageTitle';
 
 const localMessages = {
   removeTitle: { id: 'story.details.remove', defaultMessage: 'Remove from Next Snapshot' },
@@ -87,7 +87,7 @@ class MediaContainer extends React.Component {
     }
     return (
       <div>
-        <Helmet><title>{`${media.name} | ${topicName} | ${formatMessage(messages.topicsToolName)} | ${formatMessage(messages.suiteName)}`}</title></Helmet>
+        <TopicPageTitle value={media.name} />
         <Grid>
           <Row>
             <Col lg={12} md={12} sm={12}>

--- a/src/components/topic/snapshots/SnapshotBuilder.js
+++ b/src/components/topic/snapshots/SnapshotBuilder.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Helmet } from 'react-helmet';
 import { injectIntl } from 'react-intl';
+import TopicPageTitle from '../TopicPageTitle';
 
 const localMessages = {
   title: { id: 'snapshot.builder.title', defaultMessage: 'Snapshot Builder' },
@@ -9,7 +9,7 @@ const localMessages = {
 
 const SnapshotBuilder = props => (
   <div className="snapshot-builder">
-    <Helmet><title>{props.intl.formatMessage(localMessages.title)}</title></Helmet>
+    <TopicPageTitle value={localMessages.title} />
     {props.children}
   </div>
 );

--- a/src/components/topic/stories/InfluentialStoriesContainer.js
+++ b/src/components/topic/stories/InfluentialStoriesContainer.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Helmet } from 'react-helmet';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import { push } from 'react-router-redux';
@@ -17,6 +16,7 @@ import withHelp from '../../common/hocs/HelpfulContainer';
 import { pagedAndSortedLocation } from '../../util/location';
 import withPaging from '../../common/hocs/PagedContainer';
 import { HELP_STORIES_CSV_COLUMNS } from '../../../lib/helpConstants';
+import TopicPageTitle from '../TopicPageTitle';
 
 const localMessages = {
   title: { id: 'topic.influentialStories.title', defaultMessage: 'Influential Stories' },
@@ -46,12 +46,11 @@ class InfluentialStoriesContainer extends React.Component {
   render() {
     const { stories, showTweetCounts, sort, topicId, previousButton, nextButton, helpButton } = this.props;
     const { formatMessage } = this.props.intl;
-    const titleHandler = parentTitle => `${formatMessage(localMessages.title)} | ${parentTitle}`;
     return (
       <Grid>
         <Row>
           <Col lg={12} md={12} sm={12}>
-            <Helmet><title>{titleHandler()}</title></Helmet>
+            <TopicPageTitle value={localMessages.title} />
             <DataCard border={false}>
               <div className="actions">
                 <DownloadButton tooltip={formatMessage(messages.download)} onClick={this.downloadCsv} />

--- a/src/components/topic/stories/InfluentialStoryExplorerContainer.js
+++ b/src/components/topic/stories/InfluentialStoryExplorerContainer.js
@@ -1,12 +1,12 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Helmet } from 'react-helmet';
 import { FormattedMessage, FormattedHTMLMessage, injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import { Grid, Row, Col } from 'react-flexbox-grid/lib';
 import { fetchTopicStoryCounts } from '../../../actions/topicActions';
 import withAsyncFetch from '../../common/hocs/AsyncContainer';
 import InfluentialStoryExplorer from './InfluentialStoryExplorer';
+import TopicPageTitle from '../TopicPageTitle';
 
 const localMessages = {
   title: { id: 'topic.influentialStoryExplorer.title', defaultMessage: 'Story Explorer' },
@@ -26,8 +26,6 @@ class InfluentialStoryExplorerContainer extends React.Component {
 
   render() {
     const { counts, topicId, filters, selectedTimespan } = this.props;
-    const { formatMessage } = this.props.intl;
-    const titleHandler = parentTitle => `${formatMessage(localMessages.title)} | ${parentTitle}`;
     let content = null;
     if (counts.count > MAX_STORIES) {
       content = (
@@ -46,10 +44,10 @@ class InfluentialStoryExplorerContainer extends React.Component {
     }
     return (
       <div className="story-explorer">
+        <TopicPageTitle value={localMessages.title} />
         <Grid>
           <Row>
             <Col lg={12} md={12} sm={12}>
-              <Helmet><title>{titleHandler()}</title></Helmet>
               <h1><FormattedMessage {...localMessages.title} /></h1>
               <p><FormattedHTMLMessage {...localMessages.intro} /></p>
               {content}

--- a/src/components/topic/stories/StoryContainer.js
+++ b/src/components/topic/stories/StoryContainer.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Helmet } from 'react-helmet';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import { push } from 'react-router-redux';
 import Dialog from '@material-ui/core/Dialog';
@@ -34,11 +33,11 @@ import StatBar from '../../common/statbar/StatBar';
 import AppButton from '../../common/AppButton';
 import { urlToTopicMapper } from '../../../lib/urlUtil';
 import { filteredLinkTo } from '../../util/location';
+import TopicPageTitle from '../TopicPageTitle';
 
 const MAX_STORY_TITLE_LENGTH = 70; // story titles longer than this will be trimmed and ellipses added
 
 const localMessages = {
-  mainTitle: { id: 'story.details.mainTitle', defaultMessage: 'Story: {title} | {topicName} | Topic Manager | Media Cloud' },
   removeTitle: { id: 'story.details.remove', defaultMessage: 'Remove from Next Snapshot' },
   removeAbout: { id: 'story.details.remove.about', defaultMessage: 'If story is clearly not related to the Topic, or is messing up your analysis, you can remove it from the next Snapshot.  Be careful, because this means it won\'t show up anywhere on the new Snapshot you generate.' },
   unknownLanguage: { id: 'story.details.language.unknown', defaultMessage: 'Unknown' },
@@ -81,7 +80,7 @@ class StoryContainer extends React.Component {
     }
     return (
       <div>
-        <Helmet><title>{formatMessage(localMessages.mainTitle, { title: displayTitle, topicName })}</title></Helmet>
+        <TopicPageTitle value={storyInfo.title} />
         <Grid>
           <Row>
             <Col lg={12}>

--- a/src/components/topic/words/InfluentialWordsContainer.js
+++ b/src/components/topic/words/InfluentialWordsContainer.js
@@ -1,12 +1,12 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Helmet } from 'react-helmet';
 import { connect } from 'react-redux';
 import { injectIntl, FormattedMessage } from 'react-intl';
 import { Grid, Row, Col } from 'react-flexbox-grid/lib';
 import Word2VecTimespanPlayerContainer from './Word2VecTimespanPlayerContainer';
 import WordCloudComparisonContainer from './WordCloudComparisonContainer';
 import FociWordComparison from './FociWordComparison';
+import TopicPageTitle from '../TopicPageTitle';
 
 const localMessages = {
   title: { id: 'topic.influentialWords.title', defaultMessage: 'Influential Words' },
@@ -15,7 +15,7 @@ const localMessages = {
 
 const InfluentialWordsContainer = props => (
   <Grid>
-    <Helmet><title>{props.intl.formatMessage(localMessages.title)}</title></Helmet>
+    <TopicPageTitle value={localMessages.title} />
     <Row>
       <Col lg={12} md={12} sm={12}>
         <h1><FormattedMessage {...localMessages.title} /></h1>

--- a/src/components/topic/words/WordContainer.js
+++ b/src/components/topic/words/WordContainer.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Helmet } from 'react-helmet';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import { Grid, Row, Col } from 'react-flexbox-grid/lib';
@@ -10,8 +9,8 @@ import WordWordsContainer from './WordWordsContainer';
 import WordStoriesContainer from './WordStoriesContainer';
 import WordSplitStoryCountContainer from './WordSplitStoryCountContainer';
 import WordInContextContainer from './WordInContextContainer';
-import messages from '../../../resources/messages';
 import WordSimilarWordsContainer from './WordSimilarWordsContainer';
+import TopicPageTitle from '../TopicPageTitle';
 
 const localMessages = {
   mainTitle: { id: 'word.details.mainTitle', defaultMessage: 'Word: "{title}"' },
@@ -36,7 +35,7 @@ class WordContainer extends React.Component {
     const { formatMessage } = this.props.intl;
     return (
       <div>
-        <Helmet><title>{`${formatMessage(localMessages.mainTitle, { title: term })} | ${topicName} | ${formatMessage(messages.topicsToolName)} | ${formatMessage(messages.suiteName)}`}</title></Helmet>
+        <TopicPageTitle value={formatMessage(localMessages.mainTitle, { title: term })} />
         <Grid>
           <Row>
             <Col lg={12}>

--- a/src/components/user/ChangePasswordContainer.js
+++ b/src/components/user/ChangePasswordContainer.js
@@ -6,11 +6,13 @@ import { push } from 'react-router-redux';
 import { changePassword } from '../../actions/userActions';
 import ChangePasswordForm from './ChangePasswordForm';
 import messages from '../../resources/messages';
+import PageTitle from '../common/PageTitle';
 
 const ChangePasswordContainer = (props) => {
   const { handlePasswordChange } = props;
   return (
     <Grid>
+      <PageTitle value={messages.userChangePassword} />
       <ChangePasswordForm
         titleMsg={messages.userChangePassword}
         buttonMsg={messages.userChangePassword}

--- a/src/components/user/LoginFormContainer.js
+++ b/src/components/user/LoginFormContainer.js
@@ -2,9 +2,9 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { Grid, Row, Col } from 'react-flexbox-grid/lib';
-import { Helmet } from 'react-helmet';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import LoginForm from './LoginForm';
+import PageTitle from '../common/PageTitle';
 
 const localMessages = {
   loginTitle: { id: 'login.title', defaultMessage: 'Login' },
@@ -18,11 +18,11 @@ class LoginContainer extends React.Component {
   }
 
   render() {
-    const { formatMessage, isLoggedIn } = this.props.intl;
+    const { isLoggedIn } = this.props.intl;
     const className = `logged-in-${isLoggedIn}`;
     return (
       <Grid>
-        <Helmet><title>{formatMessage(localMessages.loginTitle)}</title></Helmet>
+        <PageTitle value={localMessages.loginTitle} />
         <Row>
           <Col lg={12} className={className}>
             <h2><FormattedMessage {...localMessages.loginTitle} /></h2>

--- a/src/components/user/RequestPasswordReset.js
+++ b/src/components/user/RequestPasswordReset.js
@@ -12,6 +12,7 @@ import AppButton from '../common/AppButton';
 import messages from '../../resources/messages';
 import { invalidEmail } from '../../lib/formValidators';
 import withIntlForm from '../common/hocs/IntlForm';
+import PageTitle from '../common/PageTitle';
 
 const localMessages = {
   title: { id: 'user.forgotPassword.title', defaultMessage: 'Forgot Your Password?' },
@@ -26,6 +27,7 @@ const RequestPasswordReset = (props) => {
   const { formatMessage } = props.intl;
   return (
     <Grid>
+      <PageTitle value={localMessages.title} />
       <form onSubmit={handleSubmit(onSubmitRecovery.bind(this))} className="app-form request-password-reset-form">
         <Row>
           <Col lg={12}>

--- a/src/components/user/SignupContainer.js
+++ b/src/components/user/SignupContainer.js
@@ -14,6 +14,7 @@ import { emptyString, invalidEmail, passwordTooShort, stringsDoNotMatch } from '
 import withIntlForm from '../common/hocs/IntlForm';
 import { addNotice } from '../../actions/appActions';
 import { LEVEL_ERROR } from '../common/Notice';
+import PageTitle from '../common/PageTitle';
 
 const localMessages = {
   intro: { id: 'user.signup.intro', defaultMessage: 'Create an account to use all our tools for free.' },
@@ -45,6 +46,7 @@ class SignupContainer extends React.Component {
     const { formatMessage } = this.props.intl;
     return (
       <Grid>
+        <PageTitle value={messages.userSignup} />
         <form onSubmit={handleSubmit(handleSignupSubmission.bind(this))} className="app-form signup-form">
           <Row>
             <Col lg={12}>

--- a/src/components/user/UserProfileContainer.js
+++ b/src/components/user/UserProfileContainer.js
@@ -2,13 +2,13 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { Grid, Row, Col } from 'react-flexbox-grid/lib';
-import { Helmet } from 'react-helmet';
 import { FormattedMessage, FormattedHTMLMessage, injectIntl } from 'react-intl';
 import messages from '../../resources/messages';
 import AppButton from '../common/AppButton';
 import { resetApiKey } from '../../actions/userActions';
 import { addNotice, updateFeedback } from '../../actions/appActions';
 import { LEVEL_ERROR } from '../common/Notice';
+import PageTitle from '../common/PageTitle';
 
 const API_REQUESTS_UNLIMITED = 0;
 
@@ -26,11 +26,10 @@ const localMessages = {
 const UserProfileContainer = (props) => {
   const { profile, handleResetApiKey } = props;
   const { formatMessage } = props.intl;
-  const titleHandler = parentTitle => `${formatMessage(messages.userProfile)} | ${parentTitle}`;
   const adminContent = (profile.auth_roles.includes('admin')) ? <FormattedHTMLMessage {...localMessages.admin} /> : null;
   return (
     <Grid>
-      <Helmet><title>{titleHandler()}</title></Helmet>
+      <PageTitle value={messages.userProfile} />
       <Row>
         <Col lg={12}>
           <h1><FormattedMessage {...messages.userProfile} /></h1>

--- a/src/lib/stringUtil.js
+++ b/src/lib/stringUtil.js
@@ -1,4 +1,5 @@
 
+// Trim a string to a max length, adding '...' if it is too long
 export function trimToMaxLength(string, maxLength) {
   if ((string === undefined) || (string === null)) {
     return string; // is this right, or should we return empty string?
@@ -9,6 +10,7 @@ export function trimToMaxLength(string, maxLength) {
   return `${string.substring(0, maxLength)}...`;
 }
 
+// Use this to handle really big numbers that you need to show at low accuracy
 export function humanReadableNumber(number, numSigFigs, formatNumber) {
   const pow = Math.round(number).toString().length;
 
@@ -29,4 +31,12 @@ export function humanReadableNumber(number, numSigFigs, formatNumber) {
   }
 
   return formatNumber(number);
+}
+
+// Use this to intl a variable when you don't know if it is a string or a message object
+export function intlIfObject(formatter, value) {
+  if (typeof value === 'string') {
+    return value;
+  }
+  return formatter(value);
 }

--- a/src/styles/topics/_topic_table.scss
+++ b/src/styles/topics/_topic_table.scss
@@ -1,6 +1,7 @@
 @import '../_constants';
 
 .topic-table {
+  padding-bottom: 30px;
 
   tr.topic-state-error {
     .topic-state {


### PR DESCRIPTION
This updates the page titles for all pages across the app, and adds a new architecture for going forward. The point is that this totally isolates the library we use for page titles from the fact that we want them, and we can chance the format of them in one place (`PageTitle`).

See #1173 for implementation details. Commit 8eb9f67e8b5cb33f08495de2438a068298b61b1d is the key one that has the new simple architecture. The others are just using it across all the pages.