### PR TITLE
Remove newsletter option on signup

### DIFF
--- a/server/views/user.py
+++ b/server/views/user.py
@@ -60,14 +60,11 @@ def permissions_for_user():
 @api_error_handler 
 def signup():
     logger.debug("reg request from %s", request.form['email'])
-    subscribe_to_newsletter = 0
-    if ('subscribeToNewsletter' in request.form) and (request.form['subscribeToNewsletter'] == 'true'):
-        subscribe_to_newsletter = 1
     results = mc.authRegister(request.form['email'],
                               request.form['password'],
                               request.form['fullName'],
                               request.form['notes'],
-                              subscribe_to_newsletter,
+                              False,    # removing subscribe_to_newsletter option
                               ACTIVATION_URL)
     return jsonify(results)
 

--- a/src/components/common/mediaPicker/MediaPickerDialog.js
+++ b/src/components/common/mediaPicker/MediaPickerDialog.js
@@ -101,6 +101,12 @@ class MediaPickerDialog extends React.Component {
                     type="submit"
                     primary
                   />
+                <AppButton
+                    className="select-media-cancel-button"
+                    label={formatMessage(messages.cancel)}
+                    onTouchTap={() => this.handleRemoveDialogClose(false)}
+                    type="submit"
+                  />
                 </div>
                 <div className="select-media-content">
                   <MediaPickerResultsContainer timestamp={lookupTimestamp} selectedMediaQueryType={PICK_FEATURED} selectedMedia={selectedMedia} handleSelection={handleSelection} />

--- a/src/components/user/SignupContainer.js
+++ b/src/components/user/SignupContainer.js
@@ -24,7 +24,6 @@ const localMessages = {
   missingNotes: { id: 'user.missingNotes', defaultMessage: 'You have to tell us a little about why you want to use Media Cloud.' },
   feedback: { id: 'user.signUp.feedback', defaultMessage: 'Successfully signed up.' },
   notesHint: { id: 'user.notes.hint', defaultMessage: 'Tell us a little about what you want to use Media Cloud for' },
-  subscribeToNewsletter: { id: 'user.signUp.subscribeToNewsletter', defaultMessage: 'Subscribe to Newsletter?' },
   userAlreadyExists: { id: 'user.signUp.error.alreadyExists', defaultMessage: 'Sorry, but a user with that email already exists! Did you <a href="/#/request-password-reset">need to reset your password</a>?' },
   signupSuccess: { id: 'user.signUp.success',
     defaultMessage: '<h1>Clink the link we just emailed you</h1>'
@@ -108,15 +107,6 @@ class SignupContainer extends React.Component {
                 component={renderTextField}
                 hintText={formatMessage(localMessages.notesHint)}
                 label={messages.userNotes}
-              />
-            </Col>
-          </Row>
-          <Row>
-            <Col lg={6}>
-              <Field
-                name="subscribeToNewsletter"
-                component={renderCheckbox}
-                label={localMessages.subscribeToNewsletter}
               />
             </Col>
           </Row>

--- a/src/lib/serverApi/user.js
+++ b/src/lib/serverApi/user.js
@@ -29,7 +29,7 @@ export function resetPassword(params) {
 }
 
 export function signupUser(params) {
-  const acceptedParams = acceptParams(params, ['email', 'password', 'fullName', 'notes', 'subscribeToNewsletter']);
+  const acceptedParams = acceptParams(params, ['email', 'password', 'fullName', 'notes']);
   return createPostingApiPromise('/api/user/signup', acceptedParams);
 }
 


### PR DESCRIPTION
This removes the UI option to signup for a newsletter when creating user accounts. Simple change in a handful of files. Verified locally that I can still signup for a new account after this change.