### PR TITLE
highlight words matching queries for admins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16925,6 +16925,11 @@
         "squeak": "^1.0.0"
       }
     },
+    "logic-query-parser": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/logic-query-parser/-/logic-query-parser-0.0.5.tgz",
+      "integrity": "sha1-Vu33wBL1lMgjb9UXUHnvXaG+qTw="
+    },
     "loglevelnext": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/loglevelnext/-/loglevelnext-1.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "highcharts-treemap": "^0.1.7",
     "intl": "1.2.5",
     "isomorphic-fetch": "2.2.1",
+    "logic-query-parser": "0.0.5",
     "moment": "2.19.3",
     "nightmare-inline-download": "^0.2.2",
     "npm": "^6.4.1",

--- a/src/actions/storyActions.js
+++ b/src/actions/storyActions.js
@@ -16,7 +16,7 @@ export const fetchStoryNytThemes = createAsyncAction(FETCH_STORY_NYT_THEMES, api
 
 export const SELECT_STORY = 'SELECT_STORY';
 // pass in stories id
-export const selectStory = createAction(SELECT_STORY, id => id);
+export const selectStory = createAction(SELECT_STORY);
 export const RESET_STORY = 'RESET_STORY';
 
 export const resetStory = createAction(RESET_STORY);

--- a/src/components/common/admin/HighlightedText.js
+++ b/src/components/common/admin/HighlightedText.js
@@ -1,0 +1,26 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+// https://stackoverflow.com/questions/29652862/highlight-text-using-reactjs
+
+const HighlightedText = ({ text, search }) => {
+  if (search === undefined) {
+    return text;
+  }
+  const regex = new RegExp(`(${search.join('|')})`, 'gi');
+  const parts = text.split(regex);
+  return (
+    <span>
+      {parts.filter(part => part).map((part, i) => (
+        regex.test(part) ? <mark key={i}>{part}</mark> : <span key={i}>{part}</span>
+      ))}
+    </span>
+  );
+};
+
+HighlightedText.propTypes = {
+  text: PropTypes.string.isRequired,
+  search: PropTypes.array,
+};
+
+export default HighlightedText;

--- a/src/components/common/admin/story/StoryCachedContainer.js
+++ b/src/components/common/admin/story/StoryCachedContainer.js
@@ -6,6 +6,7 @@ import { FormattedHTMLMessage, injectIntl } from 'react-intl';
 import { selectStory, fetchStory } from '../../../../actions/storyActions';
 import withAsyncData from '../../hocs/AsyncDataContainer';
 import { ReadItNowButton } from '../../IconButton';
+import HighlightedText from '../HighlightedText';
 
 const localMessages = {
   title: { id: 'story.cached.title', defaultMessage: 'Cached Story' },
@@ -14,7 +15,7 @@ const localMessages = {
   storyText: { id: 'story.cached.text', defaultMessage: 'Story Text' },
 };
 
-const StoryCachedContainer = ({ story }) => (
+const StoryCachedContainer = ({ story, location }) => (
   <Grid>
     <h1>{story.title}</h1>
     <h3><FormattedHTMLMessage {...localMessages.intro} values={{ publishDate: story.publish_date, ref: story.media.url, link: story.media.name, collectDate: story.collect_date }} /></h3>
@@ -24,7 +25,7 @@ const StoryCachedContainer = ({ story }) => (
     <h2><FormattedHTMLMessage {...localMessages.storyText} /></h2>
     <Row>
       <Col lg={12}>
-        {story.story_text}
+        <HighlightedText text={story.story_text} search={location.query.search.split(',')} />
       </Col>
     </Row>
   </Grid>
@@ -36,6 +37,7 @@ StoryCachedContainer.propTypes = {
   // from context
   intl: PropTypes.object.isRequired,
   helpButton: PropTypes.node,
+  location: PropTypes.object.isRequired,
 };
 
 const mapStateToProps = state => ({
@@ -45,7 +47,7 @@ const mapStateToProps = state => ({
 
 
 const fetchAsyncData = (dispatch, { params }) => {
-  dispatch(selectStory(params.id));
+  dispatch(selectStory({ id: params.id }));
   dispatch(fetchStory(params.id, { text: true }));
 };
 

--- a/src/components/common/admin/story/UpdateStoryContainer.js
+++ b/src/components/common/admin/story/UpdateStoryContainer.js
@@ -93,7 +93,7 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
 
 const fetchAsyncData = (dispatch, { params }) => {
   dispatch(fetchMetadataValuesForPrimaryLanguage(TAG_SET_PRIMARY_LANGUAGE));
-  dispatch(selectStory(params.id));
+  dispatch(selectStory({ id: params.id }));
   dispatch(fetchStory(params.id));
 };
 

--- a/src/components/explorer/results/QuerySampleStoriesResultsContainer.js
+++ b/src/components/explorer/results/QuerySampleStoriesResultsContainer.js
@@ -118,7 +118,7 @@ const mapStateToProps = state => ({
 const mapDispatchToProps = dispatch => ({
   handleStorySelection: (query, story) => {
     // we should select and fetch since that's the pattern, even if we have the story info
-    dispatch(selectStory(story.stories_id));
+    dispatch(selectStory({ id: story.stories_id, search: query.q }));
     dispatch(fetchStory(story.stories_id));
   },
 });

--- a/src/components/explorer/results/QueryTotalAttentionResultsContainer.js
+++ b/src/components/explorer/results/QueryTotalAttentionResultsContainer.js
@@ -98,10 +98,11 @@ class QueryTotalAttentionResultsContainer extends React.Component {
       } else {
         downloadOptimizer = (
           <ActionMenu actionTextMsg={messages.downloadOptions}>
-            {queries.map(q => (
+            {queries.map((q, idx) => (
               <MenuItem
                 className="action-icon-menu-item"
                 onClick={() => this.downloadCsv(q)}
+                key={idx}
               >
                 <ListItemText>
                   <FormattedMessage {...localMessages.downloadCsv} values={{ name: q.label }} />

--- a/src/components/topic/stories/StoryContainer.js
+++ b/src/components/topic/stories/StoryContainer.js
@@ -244,7 +244,7 @@ const mapStateToProps = (state, ownProps) => ({
 });
 
 const fetchAsyncData = (dispatch, props) => {
-  dispatch(selectStory(props.storiesId));
+  dispatch(selectStory({ id: props.storiesId }));
   const q = {
     ...props.filters,
     id: props.topicId,

--- a/src/components/topic/stories/StoryUpdateContainer.js
+++ b/src/components/topic/stories/StoryUpdateContainer.js
@@ -89,7 +89,7 @@ const mapStateToProps = (state, ownProps) => ({
 
 
 const fetchAsyncData = (dispatch, props) => {
-  dispatch(selectStory(props.storiesId));
+  dispatch(selectStory({ id: props.storiesId }));
   dispatch(fetchStory(props.topicId, props.storiesId));
   dispatch(fetchMetadataValuesForPrimaryLanguage(TAG_SET_PRIMARY_LANGUAGE));
 };

--- a/src/reducers/story/info.js
+++ b/src/reducers/story/info.js
@@ -26,7 +26,7 @@ const info = createAsyncReducer({
     geocoderVersion: tagWithTagSetsId(payload.story_tags, TAG_SET_GEOCODER_VERSION),
     nytThemesVersion: tagWithTagSetsId(payload.story_tags, TAG_SET_NYT_THEMES_VERSION),
   }),
-  [SELECT_STORY]: payload => ({ id: payload, selectedStory: true }),
+  [SELECT_STORY]: payload => ({ ...payload, selectedStory: true }),
   [RESET_STORY]: () => ({ fetchStatus: '', fetchStatuses: [], id: null, stories_id: null }),
 });
 

--- a/src/reducers/topics/selected/story/info.js
+++ b/src/reducers/topics/selected/story/info.js
@@ -27,7 +27,7 @@ const info = createAsyncReducer({
     geocoderVersion: tagWithTagSetsId(payload.story_tags, TAG_SET_GEOCODER_VERSION),
     nytThemesVersion: tagWithTagSetsId(payload.story_tags, TAG_SET_NYT_THEMES_VERSION),
   }),
-  [SELECT_STORY]: payload => ({ id: payload }),
+  [SELECT_STORY]: payload => ({ ...payload }),
 });
 
 export default info;


### PR DESCRIPTION
For #1599.  This required refactoring the `selectStory` action to accept more than just and ID, so it has touchpoints in a few places. That action now accepts an object, so that we can pass the query string over to the `SelectedStoryDrillDownContainer`, which the uses the `logic-query-parser` library to translate the boolean logic query into a parsed tree we can extract strings from. The extraction isn't perfect, but I think it'll be a fine 80/20 that handles most queries.  I tried it on some reasonable complex one and it parsed pretty well.