### PR TITLE
Update instructions for installing MongoDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Node and npm:
  * `npm install` to install all the package dependencies (as specified in the `package.json`)
 
 MongoDB:
-[Install MongoDb](https://docs.mongodb.com/manual/installation/).  We develop on OS X and install via the [HomeBrew package manager](http://brew.sh): `brew install mongodb`
+[Install MongoDb](https://docs.mongodb.com/manual/administration/install-community/).
 
 Redis:
 [Install Redis](http://redis.io/)  We develop on OS X and install via the [HomeBrew package manager](http://brew.sh): `brew install redis`

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ Node and npm:
  * `npm install` to install all the package dependencies (as specified in the `package.json`)
 
 MongoDB:
-[Install MongoDb](https://docs.mongodb.com/manual/administration/install-community/).
+[Install MongoDb](https://docs.mongodb.com/manual/administration/install-community/):
+* `brew tap mongodb/brew`
+* `brew install mongodb-community@4.2`
 
 Redis:
 [Install Redis](http://redis.io/)  We develop on OS X and install via the [HomeBrew package manager](http://brew.sh): `brew install redis`


### PR DESCRIPTION
I updated this to just link to the mongo instructions (the original `brew` ones are outdated.