### PR TITLE
Added Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+requirements.py:
+	pip install -q -r requirements.txt --exists-action w
+


### PR DESCRIPTION
Would either of you be opposed to a `Makefile`? I will just never remember the right incantations for installing requirements and I think this would be a nice shortcut we could use for consistent installs. We can also add other commands that we want to standardize.

I'll be looking for both of you to agree to this before merging and will add to the docs (just didn't want to invest in that before you agree to adding a `Makefile`).