### PR TITLE
Switch to new query data helper #1862

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Flask==1.1.2
 Flask-Login==0.5.0
 Flask-Webpack==0.1.0
-mediacloud==3.11.3
+mediacloud==3.12.0
 pymongo==3.10.1
 requests==2.23.0
 raven[flask]==6.10.0

--- a/server/platforms/web_mediacloud.py
+++ b/server/platforms/web_mediacloud.py
@@ -91,5 +91,5 @@ class WebMediaCloudProvider(ContentProvider):
         media_ids = kwargs['sources'] if 'sources' in kwargs else []
         tags_ids = kwargs['collections'] if 'collections' in kwargs else []
         q = concatenate_query_for_solr(query, media_ids, tags_ids)
-        fq = MediaCloud.publish_date_query(start_date, end_date)
+        fq = MediaCloud.dates_as_query_clause(start_date, end_date)
         return q, fq

--- a/server/views/explorer/__init__.py
+++ b/server/views/explorer/__init__.py
@@ -21,7 +21,7 @@ def dates_as_filter_query(start_date, end_date):
     if start_date:
         testa = datetime.datetime.strptime(start_date, '%Y-%m-%d').date()
         testb = datetime.datetime.strptime(end_date, '%Y-%m-%d').date()
-        date_query = mc.publish_date_query(testa, testb, True, True)
+        date_query = mc.dates_as_query_clause(testa, testb)
     return date_query
 
 

--- a/server/views/topics/__init__.py
+++ b/server/views/topics/__init__.py
@@ -89,8 +89,8 @@ def concatenate_query_for_solr(solr_seed_query=None, media_ids=None, tags_ids=No
 
 
 def concatenate_solr_dates(start_date, end_date):
-    publish_date = mediacloud.api.MediaCloud.publish_date_query(
+    publish_date = mediacloud.api.MediaCloud.dates_as_query_clause(
         datetime.datetime.strptime(start_date, '%Y-%m-%d').date(),
-        datetime.datetime.strptime(end_date, '%Y-%m-%d').date(), True, True)
+        datetime.datetime.strptime(end_date, '%Y-%m-%d').date())
 
     return publish_date


### PR DESCRIPTION
This small change fixed #1862. This is mostly for cleanup, but does effect some story counts shown to users in non-research-critical places:
* source manager attention charts
* topic version seed query totals

Note that bumps the mediacloud-api library dependency up, so you'll have to `pip install` to get the latest library for it to work. Let me know how it looks and I'll merge.