### PR TITLE
Added "total" field to topic sample preview

### DIFF
--- a/server/views/platforms.py
+++ b/server/views/platforms.py
@@ -64,7 +64,7 @@ def api_platforms_sample():
     except NotImplementedError:  # if this provider doesn't support previewing the data, let the client know
         content_list = []
         supported = False
-    return jsonify({'list': content_list, 'supported': supported})
+    return jsonify({'list': content_list, 'total': len(content_list), 'supported': supported})
 
 
 @app.route('/api/platforms/count', methods=['POST'])


### PR DESCRIPTION
Fixes #1871 

The frontend expected `total` to be present. There are two ways to fix this (inferring the total from the story count on the frontend or returning the count via the API) and from poking around, it seems like returning it on the API is closer to the standard, so that's what I've done here.

N.B. Making this PR against `topics-multi-platform`.