### PR TITLE
Fix new explorer attention over time not appearing

### DIFF
--- a/src/lib/explorerUtil.js
+++ b/src/lib/explorerUtil.js
@@ -79,7 +79,7 @@ export function ensureSafeResults(queries, results) {
   const resultUids = Object.keys(results);
   const validQueries = queries
     .filter(q => q.deleted !== true) // undeleted queries
-    .filter(q => resultUids.includes(q.uid)); // and those that have results
+    .filter(q => resultUids.includes(`${q.uid}`)); // and those that have results
   const validQueriesWithResults = validQueries.map(q => ({
     ...q,
     results: results[q.uid],


### PR DESCRIPTION
Fixes #1915

Is it worth figuring out what the underlying cause of the UIDs being inconsistent? New ones appear to be ints, whereas when reloading from the page results in more UID-like identifiers.

N.B. Making this PR against `v3.14.x`.