### PR TITLE
Fix local development when redux tools unavailable

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -20,11 +20,11 @@ const middlewares = [
 
 function configDevelopmentStore(appName) {
   /* eslint-disable no-underscore-dangle */
-  return createStore(getRootReducer(appName), {}, compose(
-    applyMiddleware(...middlewares),
-    window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
-  ));
+  const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
   /* eslint-enable */
+  return createStore(getRootReducer(appName), {}, composeEnhancers(
+    applyMiddleware(...middlewares)
+  ));
 }
 
 function configProductionStore(appName) {


### PR DESCRIPTION
Solution found on https://github.com/zalmoxisus/redux-devtools-extension#12-advanced-store-setup.

Without this fix, we get the following error if redux tools are unavailable when developing locally:
```
Uncaught TypeError: Cannot read property 'apply' of undefined
    at eval (redux.js:608)
    at createStore (redux.js:87)
    at configDevelopmentStore (store.js:32)
    at getStore (store.js:51)
    at reallyInitializeApp (index.js:51)
    at initializeApp (index.js:170)
    at eval (topicsIndex.js:28)
    at Module../src/topicsIndex.js (app_js.05f18c2f0599af80ea91.js:34431)
    at __webpack_require__ (app_js.05f18c2f0599af80ea91.js:20)
    at eval (webpack:///multi_(:5000/webpack)-dev-server/client?:2:18)
```