### PR TITLE
Added sync-frontend-db custom command

### DIFF
--- a/.flaskenv
+++ b/.flaskenv
@@ -1,0 +1,1 @@
+FLASK_APP="server"

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -12,6 +12,7 @@ mediacloud-cliff==2.6.1
 gunicorn==20.0.4
 dogpile.cache==0.7.1  # upgrading dogpile.cache caused problems - leave it on this version
 python-dateutil==2.8.1
+python-dotenv==0.13.0
 python-slugify==4.0.0
 greenlet==0.4.15
 deco==0.5.2

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -18,6 +18,7 @@ from flask_executor import Executor
 
 from server.sessions import RedisSessionInterface
 from server.util.config import get_default_config, ConfigException
+from server.commands import sync_frontend_db
 from server.database import UserDatabase, AnalyticsDatabase
 
 SERVER_MODE_DEV = "dev"
@@ -172,6 +173,9 @@ def create_app():
         my_app.config['REMEMBER_COOKIE_DOMAIN'] = cookie_domain
     # connect to the shared session storage
     my_app.session_interface = RedisSessionInterface(redis.StrictRedis.from_url(config.get('SESSION_REDIS_URL')))
+
+    my_app.cli.add_command(sync_frontend_db)
+
     return my_app
 
 

--- a/server/commands/__init__.py
+++ b/server/commands/__init__.py
@@ -4,7 +4,7 @@ import click
 from flask.cli import with_appcontext
 
 
-def fetch_backend_emails():
+def _fetch_backend_emails():
     from server import mc
     first = True
     link_id = None
@@ -27,7 +27,7 @@ def sync_frontend_db(test):
     will be deleted.
     """
     from server import user_db
-    backend_emails = fetch_backend_emails()
+    backend_emails = _fetch_backend_emails()
     print("'{}' backend users".format(len(backend_emails)))
 
     users_to_remove = user_db.get_users({

--- a/server/commands/__init__.py
+++ b/server/commands/__init__.py
@@ -1,0 +1,48 @@
+# pylint: disable=import-outside-toplevel
+
+import click
+from flask.cli import with_appcontext
+
+
+def fetch_backend_emails():
+    from server import mc
+    first = True
+    link_id = None
+    backend_emails = []
+    while first or link_id:
+        first = False
+        page = mc.userList(link_id=link_id)
+        link_id = page["link_ids"].get("next")
+        backend_emails = backend_emails + [user["email"] for user in page["users"]]
+    return backend_emails
+
+
+@click.command("sync-frontend-db")
+@click.option('--test', required=False, type=bool, default=False,
+              help="Fetches and display number of users to delete only. Doesn't perform delete.")
+@with_appcontext
+def sync_frontend_db(test):
+    """
+    Synchronize the frontend user database with the backend. Users in the frontend database not found in the backend
+    will be deleted.
+    """
+    from server import user_db
+    backend_emails = fetch_backend_emails()
+    print("'{}' backend users".format(len(backend_emails)))
+
+    users_to_remove = user_db.get_users({
+        "$and":
+            [{"username": {"$ne": email}} for email in backend_emails]
+    })
+    print("'{}' users to remove".format(users_to_remove.count()))
+
+    if test:
+        print("Testing only! No users deleted.")
+    elif users_to_remove.count() > 0:
+        user_db.delete_users({
+            "$or":
+                [{"username": {"$eq": user["username"]}} for user in users_to_remove]
+        })
+        print("Successfully deleted users")
+    else:
+        print("No users to delete")

--- a/server/database.py
+++ b/server/database.py
@@ -6,8 +6,8 @@ logger = logging.getLogger(__name__)
 
 
 class AppDatabase:
-    # DB wrapper for accessing local storge that supports the app.
-    # In theory this makes switching out storage backends easier, by gauranteeing _conn is private.
+    # DB wrapper for accessing local storage that supports the app.
+    # In theory this makes switching out storage backends easier, by guaranteeing _conn is private.
 
     def __init__(self, db_uri):
         self.uri = db_uri
@@ -65,6 +65,12 @@ class UserDatabase(AppDatabase):
 
     def update_user(self, username, values_to_update):
         return self._conn.users.update_one({'username': username}, {'$set': values_to_update})
+
+    def get_users(self, query_operator=None):
+        return self._conn.users.find(query_operator or {})
+
+    def delete_users(self, query_operator=None):
+        return self._conn.users.delete_many(query_operator or {})
 
 
 class AnalyticsDatabase(AppDatabase):

--- a/server/database.py
+++ b/server/database.py
@@ -69,8 +69,8 @@ class UserDatabase(AppDatabase):
     def get_users(self, query_operator=None):
         return self._conn.users.find(query_operator or {})
 
-    def delete_users(self, query_operator=None):
-        return self._conn.users.delete_many(query_operator or {})
+    def delete_users(self, query_operator):
+        return self._conn.users.delete_many(query_operator)
 
 
 class AnalyticsDatabase(AppDatabase):


### PR DESCRIPTION
First part of #1890

* Adds `flask sync-frontend-db`
* Adds `..flaskenv` for convenience in running flask command line

The new command calls the backend API to fetch users, diffs with the frontend, and removes users extra users.

N.B. PR will merge to `3.14.x`.