### PR TITLE
Fixed default for _parse_optional_args

### DIFF
--- a/server/views/topics/provider.py
+++ b/server/views/topics/provider.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 
 def _parse_optional_args(arg_names: List, custom_defaults: Dict = None) -> Dict:
-    custom_defaults = [] if custom_defaults is None else custom_defaults
+    custom_defaults = {} if custom_defaults is None else custom_defaults
     parsed_args = {}
     for js_name in arg_names:
         python_name = camel_to_snake(js_name)


### PR DESCRIPTION
I noticed an error in the console and found that this default was being set to a list rather than a dict. I'm sure there were other issues with this, but one that I saw was that top stories weren't loading. 

FYI, I actually don't think that this bug ever made it to production.