### PR TITLE
Fixed review sources "remove" label

### DIFF
--- a/src/components/source/collection/ManageSourcesContainer.js
+++ b/src/components/source/collection/ManageSourcesContainer.js
@@ -241,7 +241,7 @@ class ManageSourcesContainer extends React.Component {
                         color="secondary"
                         variant="outlined"
                         className="source-remove-feeds-button"
-                        label={formatMessage(localMessages.remove)}
+                        label={formatMessage(localMessages.remove, { count: '' })}
                         onClick={() => removeSource(collectionId, [source])}
                       />
                     );


### PR DESCRIPTION
I noticed that errors were being through when formatting the "remove" string.

It's asking for a "count" variable on https://github.com/mitmedialab/MediaCloud-Web-Tools/blob/main/src/components/source/collection/ManageSourcesContainer.js#L45.

https://github.com/mitmedialab/MediaCloud-Web-Tools/blob/main/src/components/source/collection/ManageSourcesContainer.js#L132 shows an example of how it's done in the same file.