### PR TITLE
Remove unset collection ID

### DIFF
--- a/src/components/source/collection/SelectCollectionContainer.js
+++ b/src/components/source/collection/SelectCollectionContainer.js
@@ -23,10 +23,6 @@ const localMessages = {
 };
 
 class SelectCollectionContainer extends React.Component {
-  componentWillUnmount() {
-    const { removeCollectionId } = this.props;
-    removeCollectionId();
-  }
 
   searchInExplorer = (evt) => {
     const { collection } = this.props;
@@ -73,8 +69,6 @@ class SelectCollectionContainer extends React.Component {
 
 SelectCollectionContainer.propTypes = {
   intl: PropTypes.object.isRequired,
-  // from dispatch
-  removeCollectionId: PropTypes.func.isRequired,
   // from context
   location: PropTypes.object.isRequired,
   params: PropTypes.object.isRequired, // params from router
@@ -91,13 +85,6 @@ const mapStateToProps = (state, ownProps) => ({
   collection: state.sources.collections.selected.collectionDetails.object,
 });
 
-
-const mapDispatchToProps = dispatch => ({
-  removeCollectionId: () => {
-    dispatch(selectCollection(null));
-  },
-});
-
 const fetchAsyncData = (dispatch, { collectionId }) => {
   dispatch(selectCollection(collectionId));
   dispatch(fetchCollectionDetails(collectionId));
@@ -105,7 +92,7 @@ const fetchAsyncData = (dispatch, { collectionId }) => {
 
 export default
 injectIntl(
-  connect(mapStateToProps, mapDispatchToProps)(
+  connect(mapStateToProps)(
     withAsyncData(fetchAsyncData, ['collectionId'])(
       SelectCollectionContainer
     )


### PR DESCRIPTION
Fixes #1937

In looking at the history, it seems like the collection ID was unset in refactoring the header to display the correct name. I removed this chunk of code, which indeed fixes the problem when clicking on the back button. I also clicked around a few times to sources, collections, etc. and the header all seemed correct to me.

This is a pretty old piece of code, so I wonder the problem it was originally intended to fix as addressed in subsequent upgrades.