### PR TITLE
Update submodule URL to shared email-templates repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "server/templates/emails"]
 	path = server/templates/emails
-	url = https://github.com/berkmancenter/mediacloud-email-templates.git
+	url = https://github.com/mediacloud/email-templates.git


### PR DESCRIPTION
Hey Dennis,

I've moved the shared `email-templates` repo (used as a submodule) to our new org.

After pulling, make sure to run something along the lines of:

```
git submodule sync
git submodule update --init --recursive
```
